### PR TITLE
chore: switch to feature branch + PR workflow, add agent-browser skill

### DIFF
--- a/.claude/commands/agent-browser.md
+++ b/.claude/commands/agent-browser.md
@@ -1,0 +1,44 @@
+# Agent Browser — Visual App Testing
+
+Open the Blob RPG app in a real browser, screenshot each screen, and report what you see.
+
+## Instructions
+
+1. **Start the dev server** (if not already running):
+   - Run `npm run dev` in the background
+   - Wait a moment for Vite to be ready
+
+2. **Open the app**:
+   - Run `agent-browser open http://localhost:5173/blob-rpg/`
+   - This launches a headless Chromium browser and returns a session
+
+3. **Create screenshot directory**:
+   - Run `mkdir -p ~/Desktop/blob-rpg-screenshots`
+
+4. **Screenshot the initial screen**:
+   - Run `agent-browser screenshot --save ~/Desktop/blob-rpg-screenshots/$(date +%Y%m%d-%H%M%S)-initial.png`
+   - Read the screenshot file to see what the app looks like
+
+5. **Navigate through each screen**:
+   - Use `agent-browser snapshot` to see clickable elements on the page
+   - Click navigation elements (Town, Dungeon, Combat buttons) using `agent-browser click`
+   - After each navigation, take a screenshot with a descriptive filename:
+     - `~/Desktop/blob-rpg-screenshots/$(date +%Y%m%d-%H%M%S)-town.png`
+     - `~/Desktop/blob-rpg-screenshots/$(date +%Y%m%d-%H%M%S)-dungeon.png`
+     - `~/Desktop/blob-rpg-screenshots/$(date +%Y%m%d-%H%M%S)-combat.png`
+   - Read each screenshot to inspect the visual state
+
+6. **Close the browser session**:
+   - Run `agent-browser close`
+
+7. **Report**:
+   - Summarize what each screen looks like
+   - Note any visual issues, broken layouts, or missing elements
+   - List all screenshots saved to `~/Desktop/blob-rpg-screenshots/`
+
+## Notes
+
+- If the dev server is already running, skip step 1
+- If a screen doesn't exist yet (placeholder), still screenshot it and note that
+- Use `agent-browser snapshot` before clicking to identify the correct elements
+- All screenshots go to `~/Desktop/blob-rpg-screenshots/` with timestamped filenames

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,20 @@ Before implementing any non-trivial feature:
 
 ## Git Workflow
 
-**Branch strategy:** Main-branch flow. All work commits directly to `main`. Every commit must be deployable.
+**Branch strategy:** Feature branch + PR flow. `main` is the deploy branch — every merge to main triggers a GitHub Pages deploy.
 
-**Commit message format:** `<type>: <description>`
+### Branches
+
+- Create feature branches from `main` named `<type>/<short-description>`
+  - Examples: `feat/dungeon-grid`, `fix/encounter-gauge-reset`, `chore/add-linting`
+- Commit freely on feature branches (no need for every commit to be deployable)
+- When work is ready, open a PR to `main` using `gh pr create`
+- Squash merge PRs into `main` (one clean commit per feature)
+- Delete the feature branch after merge
+
+### Commit Message Format
+
+PR squash commits (and any direct commits to main) use: `<type>: <description>`
 
 | Prefix | Use |
 |--------|-----|
@@ -244,7 +255,7 @@ Quick reference for Claude to implement correctly. See `plans/plan.md` for detai
 - **URL:** `https://joshua-klimaszewski.github.io/blob-rpg/`
 - **Vite base path:** Set `base: '/blob-rpg/'` in `vite.config.ts`
 - **Deploy method:** GitHub Actions — build on push to `main`, deploy `dist/` to GitHub Pages
-- **Every commit to main triggers a deploy** — ensure all commits are deployable
+- **Every merge to main triggers a deploy** — PRs are squash merged, keeping main clean and deployable
 
 ---
 
@@ -260,6 +271,7 @@ Quick reference for Claude to implement correctly. See `plans/plan.md` for detai
 | Save system | localStorage (MVP) | Simple, sufficient for <5MB RPG saves. IndexedDB migration path documented. | 2026-02-07 |
 | Styling | Tailwind CSS | Utility-first for rapid iteration, easy B&W palette constraints | 2026-02-07 |
 | Build tool | Vite | Fast HMR, native TS, simple GitHub Pages deploy | 2026-02-07 |
+| Git workflow | Feature branch + PR | Clean main history, CI checks on PRs, squash merge | 2026-02-07 |
 
 ### To Decide (Pending User Interview)
 

--- a/plans/plan.md
+++ b/plans/plan.md
@@ -236,6 +236,31 @@ Blob RPG is a mobile-first, browser-based RPG inspired by Etrian Odyssey and Pok
 
 ---
 
+### ADR-006: Feature Branch + PR Workflow
+
+**Status:** Decided (2026-02-07)
+
+**Context:** The project initially used main-branch flow (all commits direct to `main`). As the project grows and CI is added, a more structured workflow is needed. Options:
+1. Main-branch flow (current) — simple, every commit deploys
+2. Feature branch + PR flow — branches per feature, squash merge to main
+3. Gitflow — develop/release/hotfix branches (heavyweight)
+
+**Decision:** Feature branch + PR flow.
+
+**Rationale:**
+- PRs provide a natural checkpoint for CI checks (lint, test, build) before merging
+- Squash merging keeps `main` history clean (one commit per feature)
+- Feature branches allow WIP commits without breaking deploy
+- Lighter than Gitflow, appropriate for solo/small team
+- `main` remains the deploy branch — every merge triggers GitHub Pages deploy
+
+**Consequences:**
+- Slightly more overhead per change (create branch, open PR, merge)
+- Need `gh` CLI for PR creation (already available)
+- Branch naming convention: `<type>/<short-description>` (e.g., `feat/dungeon-grid`)
+
+---
+
 ## Decisions Pending User Interview
 
 These decisions have been identified but need user input. Options are preserved here for discussion.
@@ -376,6 +401,24 @@ How should the skill tree be displayed on mobile?
 - Touch target minimum set as `--spacing-touch: 44px` custom token
 
 **Next sprint:** Push to deploy, verify Pages URL works, then begin Phase 2 dungeon movement.
+
+### Sprint 03 — Dev Process Upgrades (2026-02-07)
+
+**Goal:** Switch to feature branch + PR workflow and add agent-browser for visual testing.
+
+**Tasks:**
+- [x] Update CLAUDE.md Git Workflow section to feature branch + PR flow (2026-02-07)
+- [x] Add ADR-006 for workflow change (2026-02-07)
+- [x] Install `agent-browser` globally (v0.9.1) + Chromium (2026-02-07)
+- [x] Create `/agent-browser` custom slash command (`.claude/commands/agent-browser.md`) (2026-02-07)
+- [x] Update MEMORY.md to reflect new workflow (2026-02-07)
+- [x] Dogfood: commit on `chore/dev-process-upgrades` branch, open PR to main (2026-02-07)
+
+**Notes:**
+- First PR using the new workflow — dogfooding the process
+- `agent-browser` v0.9.1 uses Playwright Chromium under the hood
+
+**Next sprint:** Phase 2 — begin dungeon movement system.
 
 ---
 


### PR DESCRIPTION
## Summary
- Switch Git workflow from main-branch flow to feature branch + PR with squash merge
- Install `agent-browser` (v0.9.1) for headless browser visual testing
- Create `/agent-browser` custom slash command for Claude Code to screenshot app screens

## Changes
- **CLAUDE.md** — Git Workflow section rewritten for branch + PR flow, deployment note updated, decisions log updated
- **plans/plan.md** — ADR-006 added, Sprint 03 logged
- **.claude/commands/agent-browser.md** — New slash command template

## Test plan
- [ ] Verify CLAUDE.md Git Workflow section describes feature branch + PR flow
- [ ] Verify `/agent-browser` appears as an available slash command in Claude Code
- [ ] Verify `agent-browser --version` runs successfully (v0.9.1)
- [ ] This PR itself dogfoods the new workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)