### PR TITLE
fix: eliminate cascading setTimeout chains in combat turn advancement

### DIFF
--- a/src/stores/combatStore.ts
+++ b/src/stores/combatStore.ts
@@ -17,7 +17,7 @@ import {
   initializeCombat,
   executeAction,
   executeEnemyTurn,
-  advanceTurn,
+  advanceToNextAlive,
   calculateRewards,
   defaultRNG,
 } from '../systems/combat';
@@ -199,8 +199,8 @@ export const useCombatStore = create<CombatStore>((set, get) => ({
       return;
     }
 
-    // Atomically apply enemy action AND advance turn in one set() call
-    const advanced = advanceTurn(result.state);
+    // Atomically apply enemy action AND advance to next alive actor in one set() call
+    const advanced = advanceToNextAlive(result.state);
     set({
       combat: advanced,
       lastEvents: result.events,
@@ -211,7 +211,7 @@ export const useCombatStore = create<CombatStore>((set, get) => ({
     const { combat } = get();
     if (!combat || combat.phase !== 'active') return;
 
-    const newState = advanceTurn(combat);
+    const newState = advanceToNextAlive(combat);
     set({ combat: newState });
   },
 


### PR DESCRIPTION
## Summary
- **Root cause**: `advanceTurn()` advances exactly 1 position. Dead actors were skipped via cascading `useEffect → setTimeout(100ms) → advanceToNext → re-render → useEffect → setTimeout(100ms)...` chains. The `combat` object reference in the useEffect deps caused spurious re-runs that could reset the timer chain, stalling enemy turns indefinitely.
- **Fix**: New `advanceToNextAlive()` pure function that atomically skips all dead actors in a single state update. The CombatScreen useEffect is simplified to only handle enemy turn auto-execution, with primitive deps that don't cause spurious re-runs.
- 9 new unit tests covering: skip one dead, skip multiple consecutive dead, wrap-around, round increment, all-dead safety fallback, hasActed reset

## Test plan
- [x] All 408 tests pass (9 new `advanceToNextAlive` tests + 399 existing)
- [x] TypeScript compiles cleanly, Vite build succeeds
- [x] Manual browser test: full combat with Slime + Mossy Slime
  - Enemy turns execute without stalling
  - Killing Slime mid-combat → dead actor skipped atomically → next turn proceeds
  - Victory triggers correctly after killing both enemies
  - Round counter increments properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)