### PR TITLE
fix: make combat turn advancement atomic — eliminate setTimeout chains

### DIFF
--- a/src/components/combat/ItemMenu.tsx
+++ b/src/components/combat/ItemMenu.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useInventoryStore } from '../../stores/inventoryStore';
 import { useCombatStore } from '../../stores/combatStore';
 import { getAllConsumables } from '../../data/items/index';
-import { executeItemAction } from '../../systems/combat';
+import { executeItemAction, advanceToNextAlive } from '../../systems/combat';
 import type { ConsumableDefinition } from '../../types/economy';
 import type { CombatEntity } from '../../types/combat';
 
@@ -32,10 +32,13 @@ export function ItemMenu({ actor, party, onUse, onCancel }: ItemMenuProps) {
     // Deduct consumable from inventory
     consumeItem(selectedItem.id);
 
-    // Execute item effect in combat
+    // Execute item effect in combat and atomically advance turn
     const result = executeItemAction(combat, actor.id, target.id, selectedItem);
+    const advanced = result.state.phase === 'active'
+      ? advanceToNextAlive(result.state)
+      : result.state;
     useCombatStore.setState({
-      combat: result.state,
+      combat: advanced,
       lastEvents: result.events,
     });
 


### PR DESCRIPTION
## Summary

- **Root cause**: Turn advancement was split between the store (`selectAction`) and the component (`setTimeout(() => advanceToNext(), 300)`). This created fragile timing-dependent chains where enemy turns could get stuck on "is acting..."
- `selectAction` now **atomically** executes the action AND advances to the next alive actor in a single `set()` call — no separate `advanceToNext` needed
- Removed **all 7** `setTimeout(() => advanceToNext(), 300)` calls from CombatScreen
- Removed `advanceToNext` from the store's public API entirely
- The **only** remaining `setTimeout` is the 600ms visual delay for enemy turns (with a ref guard against double-execution)

## What was happening

Previous fix attempts (#22, #24, #29) tried to patch individual cases but kept the fundamental `selectAction → setTimeout → advanceToNext` architecture. Fixing one case (single enemy) would break another (consecutive enemies, dead enemy skip, etc.) because the timing chains were inherently fragile.

## Test plan

- [x] Added 11 new turn-flow integration tests covering all scenarios:
  - Basic player → enemy → player cycle
  - Consecutive enemy turns
  - Dead enemy skipping
  - 4-player party vs 1 enemy (exact bug scenario from screenshot)
  - Dead enemy between two live enemies  
  - Enemy skill usage
- [x] All 426 tests pass
- [x] Build clean (tsc + vite)
- [x] Visual test with agent-browser: full combat round completes without getting stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)