### PR TITLE
fix: handle enemy skill lookup without crashing

### DIFF
--- a/src/stores/combatStore.ts
+++ b/src/stores/combatStore.ts
@@ -33,11 +33,13 @@ import { getPassiveModifiers } from '../systems/character';
 
 /** Combined skill lookup: checks player skills first, then enemy skills */
 function lookupSkill(id: string): SkillDefinition {
-  const playerSkill = getSkill(id);
-  if (playerSkill) return playerSkill;
+  try {
+    return getSkill(id);
+  } catch {
+    // Not a player skill — check enemy skills
+  }
   const enemySkill = getEnemySkill(id);
   if (enemySkill) return enemySkill;
-  // Fallback — should not happen if data is consistent
   throw new Error(`Unknown skill ID: ${id}`);
 }
 


### PR DESCRIPTION
## Summary
- `getSkill()` throws on unknown IDs instead of returning `undefined`. `lookupSkill()` called it expecting a graceful fallback to `getEnemySkill()`, but the throw killed `processEnemyTurnAndAdvance()` silently — leaving combat permanently stuck on "Slime is acting..."
- Wrapped `getSkill()` in try/catch so enemy skill IDs (e.g. `slime-acid-splash`) correctly fall through to `getEnemySkill()`

## Root cause
The bug was introduced when `lookupSkill` was written to check player skills first, then enemy skills. The assumption was `getSkill()` returns `undefined` for unknown IDs, but it actually throws. One-line logic error, but it broke every enemy turn that used a skill.

## Test plan
- [x] All 426 existing tests pass
- [x] Manual testing: completed full multi-round combat with 2 slimes using enemy skills (acid-splash, sticky-slap) — no stuck turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)