### PR TITLE
chore: allow manual deploy of any branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the deploy workflow so any branch can be manually deployed to GitHub Pages
- Useful for testing feature branches on mobile without a local server

## Usage
- **CLI**: `gh workflow run deploy.yml --ref feat/my-branch`
- **GitHub UI**: Actions → "Deploy to GitHub Pages" → "Run workflow" → pick branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)