### PR TITLE
fix: award quest XP to all party members, not just active ones

### DIFF
--- a/src/components/town/GuildScreen.tsx
+++ b/src/components/town/GuildScreen.tsx
@@ -30,7 +30,7 @@ export function GuildScreen() {
     const reward = claimQuest(definitionId);
     if (reward) {
       addGold(reward.gold);
-      awardXp(reward.xp);
+      awardXp(reward.xp, true); // Award to all party members (not just active)
       if (reward.equipmentId) {
         addEquipment(reward.equipmentId, 0);
       }

--- a/src/stores/partyStore.test.ts
+++ b/src/stores/partyStore.test.ts
@@ -60,7 +60,7 @@ describe('PartyStore', () => {
   });
 
   describe('awardXp', () => {
-    it('awards XP to active party members only', () => {
+    it('awards combat XP to active party members only (default)', () => {
       usePartyStore.getState().initializeRoster();
       usePartyStore.getState().awardXp(500);
 
@@ -71,6 +71,16 @@ describe('PartyStore', () => {
         } else {
           expect(member.xp).toBe(0);
         }
+      }
+    });
+
+    it('awards quest XP to all party members when allMembers=true', () => {
+      usePartyStore.getState().initializeRoster();
+      usePartyStore.getState().awardXp(500, true);
+
+      const { roster } = usePartyStore.getState();
+      for (const member of roster) {
+        expect(member.xp).toBe(500);
       }
     });
 

--- a/src/stores/partyStore.ts
+++ b/src/stores/partyStore.ts
@@ -28,8 +28,8 @@ interface PartyStore {
   /** Get the active party members */
   getActiveParty: () => PartyMemberState[];
 
-  /** Award XP to all active party members and process level-ups */
-  awardXp: (amount: number) => void;
+  /** Award XP and process level-ups. By default awards to active members only (combat), set allMembers=true for quest rewards. */
+  awardXp: (amount: number, allMembers?: boolean) => void;
 
   /** Sync HP/TP from combat back to party roster */
   syncHpTpFromCombat: (combatParty: CombatEntity[]) => void;
@@ -61,10 +61,11 @@ export const usePartyStore = create<PartyStore>((set, get) => ({
           .filter((m): m is PartyMemberState => m !== undefined);
       },
 
-      awardXp: (amount) => {
+      awardXp: (amount, allMembers = false) => {
         set((state) => {
           const newRoster = state.roster.map((member) => {
-            if (!state.activePartyIds.includes(member.id)) return member;
+            // Skip inactive members unless allMembers is true (for quest rewards)
+            if (!allMembers && !state.activePartyIds.includes(member.id)) return member;
 
             const updated = { ...member, xp: member.xp + amount };
             const classData = getClass(updated.classId);


### PR DESCRIPTION
Resolves #40

- Added allMembers parameter to awardXp function
- Combat XP still goes to active members only (default behavior)
- Quest XP now goes to all party members (allMembers=true)
- Updated tests to cover both combat and quest XP scenarios

https://claude.ai/code/session_01FghtsoLU9P81crLvpAUPbX