### PR TITLE
Floor 1 Corridor Redesign (EO5-Style)

### DIFF
--- a/plans/foe-pursuit-redesign.md
+++ b/plans/foe-pursuit-redesign.md
@@ -1,0 +1,149 @@
+# FOE Pursuit System Redesign
+
+## Goals
+
+1. Remove audio triggers (not needed)
+2. Add `canPursue` flag to FOEs (some pursue, some patrol forever)
+3. FOEs continue moving while player is in combat
+4. Design Floor 1 corridor puzzle using pursuit mechanics
+
+## Design Changes
+
+### 1. Remove Audio
+- Delete `playAggroSound()` function from DungeonScreen.tsx
+- Remove audio trigger effect on FOE aggro events
+- Keep visual notification (red border on FOE sprite)
+
+### 2. Add `canPursue` Flag
+
+**Type Changes:**
+```typescript
+// FoeSpawnData (in dungeon types)
+interface FoeSpawnData {
+  // ... existing fields
+  readonly canPursue?: boolean  // Default: true (FOE will chase when player detected)
+}
+
+// FoeState (runtime)
+interface FoeState {
+  // ... existing fields
+  readonly canPursue: boolean  // If false, FOE stays on patrol even when player nearby
+}
+```
+
+**Behavior:**
+- `canPursue: true` (default): FOE enters aggro state when player detected, switches to chase
+- `canPursue: false`: FOE ignores player, follows patrol path forever (puzzle FOEs)
+
+### 3. FOE Movement Logic
+
+**Current:**
+- FOEs move one step per player move
+
+**New:**
+- FOEs move one step per player move on field
+- **FOEs continue moving one step per player combat turn** (while player is in battle)
+- This creates risk: if player takes too long in combat, pursuing FOE might catch up
+- Opens puzzle opportunities: lead FOE away, start combat, FOE leaves area
+
+**Implementation:**
+- When player enters combat, store dungeon state
+- After each combat turn (player or enemy), call FOE movement logic
+- Update dungeon FOE positions (visible on return to field)
+
+### 4. Floor 1 Corridor Puzzle
+
+**Layout:**
+```
+ENTRANCE
+   |
+   v
+[Corridor 1] -- FOE patrol blocks exit ---> EXIT (to Floor 2)
+   |
+   |
+[Corridor 2 - Loop]
+   |
+   +---[back to Corridor 1]
+```
+
+**Puzzle Flow:**
+1. Player reaches intersection, sees FOE patrolling in front of exit
+2. FOE has `canPursue: true` and patrol path blocking exit
+3. When player gets close, FOE detects and pursues
+4. Player leads FOE into Corridor 2 (the loop)
+5. Player loops back to Corridor 1 while FOE is still in loop
+6. Player reaches exit to Floor 2
+7. Later, player can return and defeat FOE for loot
+
+**FOE Configuration:**
+```typescript
+{
+  id: 'foe-floor1-guardian',
+  name: 'Verdant Guardian',
+  position: { x: 15, y: 8 },  // Near exit
+  pattern: 'patrol',
+  patrolPath: [
+    { x: 15, y: 8 },
+    { x: 16, y: 8 },
+    { x: 17, y: 8 },  // Blocks exit
+    { x: 16, y: 8 },
+  ],
+  canPursue: true,
+  detectionRadius: 4,  // Fairly wide detection
+}
+```
+
+## Implementation Steps
+
+### Phase 1: Remove Audio (Quick)
+- [ ] Delete audio function from DungeonScreen.tsx
+- [ ] Remove audio trigger useEffect
+- [ ] Test: FOE aggro still shows visual notification
+
+### Phase 2: Add canPursue Flag
+- [ ] Update FoeSpawnData type with `canPursue?: boolean`
+- [ ] Update FoeState type with `canPursue: boolean`
+- [ ] Update FOE initialization to copy canPursue (default true)
+- [ ] Update FOE movement logic: skip aggro transition if `!canPursue`
+- [ ] Test: FOE with canPursue=false stays on patrol
+
+### Phase 3: FOE Movement During Combat
+- [ ] Add FOE movement call in combat store after each turn
+- [ ] Update dungeon state with new FOE positions during combat
+- [ ] Ensure FOE collision detected if player returns to field on same tile
+- [ ] Test: FOE moves while player in combat
+
+### Phase 4: Floor 1 Puzzle
+- [ ] Design floor 1 layout with corridor loop
+- [ ] Add Guardian FOE with pursuit enabled
+- [ ] Position patrol path to block exit
+- [ ] Add help text explaining FOE pursuit
+- [ ] Test: Player can lure FOE away and reach exit
+
+## Testing Checklist
+
+- [ ] Build succeeds
+- [ ] All tests pass
+- [ ] FOE with canPursue=true chases player
+- [ ] FOE with canPursue=false ignores player
+- [ ] FOE moves during player combat
+- [ ] Floor 1 puzzle solvable by luring FOE
+- [ ] No audio triggers (removed)
+- [ ] Visual FOE aggro notification still works
+
+## Files to Modify
+
+1. **src/types/dungeon.ts** - Add canPursue to FoeSpawnData and FoeState
+2. **src/systems/dungeon.ts** - Update FOE movement logic
+3. **src/components/dungeon/DungeonScreen.tsx** - Remove audio
+4. **src/stores/dungeonStore.ts** - Initialize canPursue
+5. **src/stores/combatStore.ts** - Call FOE movement after turns
+6. **src/data/dungeons/floor-1.ts** - Add puzzle layout and Guardian FOE
+7. **src/data/help/foe-system.ts** - Document pursuit mechanics
+
+## Notes
+
+- Combat-time FOE movement adds strategic depth (don't take forever in combat!)
+- Puzzle FOEs (canPursue=false) create navigation challenges
+- Pursuit FOEs (canPursue=true) create dynamic threats
+- This opens design space for complex puzzles on later floors

--- a/plans/plan.md
+++ b/plans/plan.md
@@ -164,9 +164,10 @@ Blob RPG is a mobile-first, browser-based RPG inspired by Etrian Odyssey, Pokém
 
 **6b — Combat & AI Depth (remaining):**
 - [ ] Enemy skill usage in AI — enemies currently only basic-attack; give enemies access to their defined skills (binds, displacement, ailments) with weighted selection based on AI pattern
-- [ ] FOE-specific combat encounters (FOEs should be significantly harder, use unique skills, have boss-like behavior)
+- [x] FOE-specific combat encounters (FOEs should be significantly harder, use unique skills, have boss-like behavior) (2026-02-10) — Created elite enemy variants (2x HP, +30% stats) for all FOE encounter tables
 - [ ] Boss encounter on Floor 3 (gate the dungeon exit behind a mandatory boss fight)
-- [ ] FOE respawn on floor re-entry (CLAUDE.md specifies this, not implemented)
+- [x] FOE respawn on floor re-entry (CLAUDE.md specifies this, not implemented) (2026-02-10) — Current behavior is correct: FOEs respawn on floor re-entry from FloorData
+- [x] FOE aggro/detection system (2026-02-10) — Implemented detection radius (3 tiles), line-of-sight check, visual (red pulsing) and audio feedback, patrol→chase transition on aggro
 - [ ] Combo counter feedback — reward multi-character combos more visibly (sound cue placeholder, screen shake, escalating text size)
 
 **6c — Onboarding & Tutorial (remaining):**
@@ -196,8 +197,8 @@ Blob RPG is a mobile-first, browser-based RPG inspired by Etrian Odyssey, Pokém
 - [ ] 4-6 new enemy types with F4-F6 encounter tables
 - [ ] Tier 3 equipment unlocked via new materials
 - [ ] New quest set for second dungeon
-- [ ] FOE with chase AI pattern (pursues player in line of sight)
-- [ ] Conditional FOE mechanics (e.g. FOE that only moves when player faces away)
+- [x] FOE with chase AI pattern (pursues player in line of sight) (2026-02-10) — Chase pattern exists; now patrol FOEs switch to chase when aggro'd
+- [ ] Conditional FOE mechanics (e.g. FOE that only moves when player faces away) — Deferred to Phase 7
 - [ ] Second dungeon boss encounter
 - [ ] Town upgrades (expanded inn services, new shop tiers)
 

--- a/research/foe-mechanics-research.md
+++ b/research/foe-mechanics-research.md
@@ -1,0 +1,243 @@
+# FOE Mechanics Research — Etrian Odyssey Study
+
+**Research Date:** 2026-02-10
+**Purpose:** Understand FOE mechanics from Etrian Odyssey to enhance Blob RPG's FOE system
+**GitHub Issue:** #44
+
+---
+
+## Current Blob RPG Implementation
+
+### What Exists
+- **Three FOE patterns**: patrol, chase, stationary
+- **Synchronous movement**: FOEs move 1 step per player step
+- **Collision detection**: Colliding with FOE triggers combat
+- **Combat distinction**: FOE encounters have `canFlee: false`, use separate encounter table (more enemies)
+- **Visibility**: FOEs only shown on tiles within player's vision radius
+- **State persistence**: FOE positions saved in suspend saves
+
+### What's Missing (from CLAUDE.md & plans)
+- ❌ FOE respawn on floor re-entry
+- ❌ Aggro/detection system (FOEs noticing player)
+- ❌ Visual/audio feedback for aggro state (red marker, sound)
+- ❌ FOE-specific enemy types (currently uses same pool as random encounters)
+- ❌ Conditional movement patterns (e.g., move only when player faces away)
+- ❌ Line-of-sight detection for chase behavior
+
+---
+
+## Etrian Odyssey FOE Mechanics
+
+### Respawn System
+**Source:** [Etrian Odyssey Wiki - FOE](https://www.etrianodyssey.wiki/wiki/FOE)
+
+- **Defeated FOEs respawn** after a time period:
+  - Etrian Odyssey I: 3 in-game days
+  - Later games: 7 in-game days
+  - Bosses: 14 in-game days
+- **Floor re-entry**: FOEs are persistent—if not defeated, they remain in their current patrol position even after player leaves and returns
+
+**Blob RPG Adaptation:**
+- No in-game day/night cycle → simpler respawn model
+- **Option 1**: FOEs respawn to original spawn position when player leaves and re-enters floor (even if not defeated)
+- **Option 2**: Track defeated FOEs per floor, respawn them after N dungeon runs or town visits
+- **Recommended**: Option 1 for MVP (simple, consistent with "each dungeon run is fresh")
+
+### Aggro/Detection System
+**Source:** [Etrian Odyssey Wiki - FOE](https://etrian.fandom.com/wiki/FOE)
+
+- **Patrol state** (default): FOE follows preset path
+- **Aggro state** (triggered): FOE notices player and begins pursuit
+- **Trigger conditions**:
+  - Player enters FOE's detection range (varies by FOE type, typically 2-4 tiles)
+  - Player is in FOE's line of sight (not blocked by walls)
+- **Visual feedback**: FOE icon turns **red** on minimap
+- **Audio feedback**: **"Bing!"** sound effect plays when aggro triggers
+- **Behavior change**: Patrol FOEs switch to chase pattern when aggro'd
+
+**Player Vision vs FOE Vision:**
+- **Player sight range**: 3-wide-4-deep area in front (directional)
+- **FOE detection**: Typically circular radius (2-4 tiles) or directional cone
+- **Map marking**: FOEs only appear on map if within 1-square radius of explored tiles
+
+**Blob RPG Adaptation:**
+- Add `aggroState: 'patrol' | 'aggro'` to FoeState
+- Add `detectionRadius: number` to FoeSpawnData (default 3 tiles)
+- When player within detection radius + line of sight → trigger aggro
+- Aggro state persists until player escapes (distance > radius + 2) or combat occurs
+- Visual: render aggro'd FOEs with red border/pulsing effect
+- Audio: play notification sound on aggro trigger
+
+### Movement Patterns
+**Source:** [Etrian Odyssey Wiki - Game Mechanics](https://etrianodyssey.wiki/wiki/Game_Mechanics)
+
+- **Synchronous**: FOEs move 1 step per player step (or per combat turn if player is in combat)
+- **Patrol**: Follow predefined path, reversing at endpoints
+- **Chase**: Move toward player using pathfinding (avoid walls)
+- **Stationary**: Don't move unless provoked
+- **Conditional** (advanced):
+  - Move only when player faces away
+  - Move only when player is in line of sight
+  - Wake up when another FOE is defeated nearby
+  - Move in response to specific tile triggers
+
+**Blob RPG Current vs Target:**
+- ✅ Patrol: Implemented (simple back-and-forth along path)
+- ✅ Chase: Implemented (Manhattan distance pathfinding)
+- ✅ Stationary: Implemented
+- ❌ Conditional patterns: Not implemented
+- ❌ Aggro-triggered chase: Not implemented (chase FOEs always chase, no detection phase)
+
+### Combat Encounters
+**Source:** [Etrian Odyssey Part #36](https://lparchive.org/Etrian-Odyssey/Update%2036/)
+
+- **Multi-FOE battles**: Up to 4 FOEs can join a single battle
+  - FOEs can join from sides/back during combat (not from front)
+  - Boss hitboxes block FOE entry
+- **Escape behavior**: If player flees, FOE returns to its original position (allowing escape even if cornered)
+- **Difficulty**: FOEs are significantly harder than random encounters
+  - Higher stats
+  - Access to advanced skills
+  - Often boss-like mechanics (multi-turn patterns, conditional skills)
+
+**Blob RPG Current vs Target:**
+- ✅ Cannot flee from FOE battles (`canFlee: false`)
+- ✅ FOE encounters spawn more enemies (`foeSize: [2, 3]` vs `randomSize: [1, 2]`)
+- ❌ FOE-specific enemy types (currently uses same pool as random encounters)
+- ❌ Multi-FOE battles (collision with multiple FOEs)
+- ❌ Escape position reset (FOE doesn't return to spawn if player flees—can't flee anyway)
+
+---
+
+## Recommended Enhancements for Blob RPG
+
+### Phase 1: Aggro System (High Impact, Low Complexity)
+**Goal:** Make FOEs feel more dynamic and threatening
+
+1. **Add aggro state to FOE system**
+   - Extend `FoeState` with `aggroState: 'patrol' | 'aggro'`
+   - Extend `FoeSpawnData` with `detectionRadius?: number` (default 3)
+   - Implement line-of-sight check (reuse fog-of-war logic)
+
+2. **Detection logic**
+   - Each turn, check if player is within FOE's detection radius
+   - Use `computeVisibleTiles()` from FOE's perspective to check line of sight
+   - If detected → trigger aggro, play sound, set `aggroState: 'aggro'`
+
+3. **Visual feedback**
+   - Render aggro'd FOEs with pulsing red border
+   - Aggro indicator on FOE sprite (red exclamation mark or glow)
+
+4. **Audio feedback**
+   - Play notification sound on aggro trigger (use existing SFX system)
+
+5. **Behavior change**
+   - Patrol FOEs switch to chase pattern when aggro'd
+   - Stationary FOEs remain stationary even when aggro'd (intimidation factor)
+   - Chase FOEs always aggro (no patrol phase)
+
+6. **De-aggro conditions**
+   - Player moves beyond `detectionRadius + 2` tiles
+   - Player enters combat with different entity (FOE resumes patrol)
+   - Player warps to town (reset all FOEs to patrol state)
+
+**Estimated Complexity:** 2-3 hours (types, logic, tests, visual polish)
+
+### Phase 2: FOE Respawn (Low Impact, Low Complexity)
+**Goal:** Make FOEs persistent obstacles across multiple dungeon runs
+
+1. **Reset FOEs on floor re-entry**
+   - When `enterDungeon()` called, FOEs spawn at original positions from `foeSpawns`
+   - This already happens—FOEs are initialized from floor data
+   - Currently correct behavior for MVP
+
+2. **Optional: Track defeated FOEs**
+   - Add `defeatedFoes: Set<string>` to DungeonProgressStore per floor
+   - After FOE combat victory, mark FOE as defeated
+   - On floor re-entry, filter out defeated FOEs if still within respawn cooldown
+   - Respawn cooldown: reset defeated FOEs after N town visits or real-time hours
+
+**Decision Needed:** Current behavior (FOEs always respawn on re-entry) matches CLAUDE.md and is simpler. Tracking defeats adds complexity without much gameplay value for MVP.
+
+**Recommended:** Mark as "works as intended"—FOEs respawn on re-entry is correct.
+
+### Phase 3: FOE-Specific Enemies (Medium Impact, Medium Complexity)
+**Goal:** Make FOE encounters feel distinct from random encounters
+
+1. **Add FOE-specific enemy types**
+   - Create 3-5 new enemy definitions for FOE encounters (e.g., "Elite Slime", "Thornblob Alpha")
+   - Higher stats (2x HP, +20% ATK/DEF vs normal variants)
+   - Access to advanced skills (bind skills, displacement skills, conditional skills)
+
+2. **Update encounter tables**
+   - Add `foeExclusive: boolean` flag to enemy definitions
+   - FOE encounter table uses FOE-exclusive enemies + weighted elite versions of normal enemies
+
+3. **Boss-like mechanics**
+   - Multi-turn patterns (e.g., FOE telegraphs heavy attack, executes next turn)
+   - Conditional skills (e.g., "If HP < 50%, enrage and gain +50% ATK")
+   - Bind/ailment resistance (FOEs resist binds more effectively)
+
+**Estimated Complexity:** 4-6 hours (enemy design, AI updates, encounter balancing, testing)
+
+### Phase 4: Conditional Movement Patterns (Low Impact, High Complexity)
+**Goal:** Create FOE puzzles inspired by Etrian Odyssey
+
+1. **New pattern types**
+   - `conditional-facing`: Move only when player faces away (direction-based)
+   - `conditional-proximity`: Move only when player is within/outside N tiles
+   - `conditional-visibility`: Move only when player can't see FOE (outside vision)
+
+2. **Implementation**
+   - Extend `FoePatternType` with new conditional variants
+   - Add pattern-specific config to `FoeSpawnData`
+   - Implement conditional checks in `moveFoes()` (evaluate condition → move or skip)
+
+3. **Testing**
+   - Add test floors showcasing conditional FOEs
+   - Ensure puzzles are solvable and don't create softlocks
+
+**Estimated Complexity:** 3-4 hours (logic, edge cases, testing)
+
+**Recommended:** Defer to post-MVP (Phase 7) — high complexity, low gameplay impact for initial release
+
+---
+
+## Implementation Priority
+
+### Must-Have (Issue #44 Scope)
+1. ✅ Aggro/detection system with visual/audio feedback
+2. ✅ Behavior change for patrol FOEs (switch to chase on aggro)
+3. ✅ De-aggro conditions (escape beyond range)
+
+### Should-Have (Enhances Issue #44)
+4. FOE-specific enemy types (elite variants with better stats/skills)
+5. Update help text to explain aggro mechanics
+
+### Nice-to-Have (Deferred)
+6. Conditional movement patterns (Phase 7)
+7. Multi-FOE battles (Phase 7)
+8. Respawn cooldown tracking (probably not needed)
+
+---
+
+## Sources
+
+- [FOE - Etrian Odyssey Wiki](https://www.etrianodyssey.wiki/wiki/FOE)
+- [FOE | Etrian Odyssey Wiki | Fandom](https://etrian.fandom.com/wiki/FOE)
+- [Game Mechanics - Etrian Odyssey Wiki](https://etrianodyssey.wiki/wiki/Game_Mechanics)
+- [Etrian Odyssey Part #36 - FOE in the Deep](https://lparchive.org/Etrian-Odyssey/Update%2036/)
+- [Do FOEs respawn? - GameFAQs](https://gamefaqs.gamespot.com/boards/934287-etrian-odyssey/41587275)
+- [FOE Walkthrough - Etrian Odyssey Untold](https://gamefaqs.gamespot.com/boards/709464-etrian-odyssey-untold-the-millennium-girl/68680539)
+
+---
+
+## Next Steps
+
+1. Present research findings and implementation plan to user
+2. Get user approval on priority (aggro system first? FOE-specific enemies? Both?)
+3. Create task list with estimated complexity
+4. Begin implementation in worktree
+5. Test with agent-browser (walk near FOE, verify aggro triggers, check visual feedback)
+6. Update help documentation
+7. Commit and create PR

--- a/src/components/dungeon/DungeonGrid.tsx
+++ b/src/components/dungeon/DungeonGrid.tsx
@@ -55,6 +55,7 @@ export function DungeonGrid({ floor, dungeon, cellSize }: DungeonGridProps) {
             cellSize={cellSize}
             gridX={foe.position.x}
             gridY={foe.position.y}
+            aggroState={foe.aggroState}
           />
         ))}
 

--- a/src/components/dungeon/DungeonGrid.tsx
+++ b/src/components/dungeon/DungeonGrid.tsx
@@ -15,7 +15,8 @@ interface DungeonGridProps {
 export function DungeonGrid({ floor, dungeon, cellSize }: DungeonGridProps) {
   const gridWidth = floor.width * cellSize
   const gridHeight = floor.height * cellSize
-  const partyRoster = usePartyStore((s) => s.roster)
+  const getActiveParty = usePartyStore((s) => s.getActiveParty)
+  const activeParty = getActiveParty()
 
   const visibleSet = useMemo(
     () => computeVisibleTiles(dungeon.playerPosition, floor),
@@ -52,7 +53,7 @@ export function DungeonGrid({ floor, dungeon, cellSize }: DungeonGridProps) {
       {dungeon.foes
         .filter((foe) => visibleSet.has(positionKey(foe.position)))
         .map((foe) => {
-          const color = getFoeColor(foe.enemyId, partyRoster)
+          const color = getFoeColor(foe.enemyId, activeParty)
           return (
             <FoeToken
               key={foe.id}

--- a/src/components/dungeon/DungeonGrid.tsx
+++ b/src/components/dungeon/DungeonGrid.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import type { DungeonState, FloorData } from '../../types/dungeon'
-import { computeVisibleTiles, getTileVisibility, positionKey } from '../../systems/dungeon'
+import { computeVisibleTiles, getTileVisibility, positionKey, getFoeColor } from '../../systems/dungeon'
+import { usePartyStore } from '../../stores/partyStore'
 import { DungeonTile } from './DungeonTile'
 import { PlayerToken } from './PlayerToken'
 import { FoeToken } from './FoeToken'
@@ -14,6 +15,7 @@ interface DungeonGridProps {
 export function DungeonGrid({ floor, dungeon, cellSize }: DungeonGridProps) {
   const gridWidth = floor.width * cellSize
   const gridHeight = floor.height * cellSize
+  const partyRoster = usePartyStore((s) => s.roster)
 
   const visibleSet = useMemo(
     () => computeVisibleTiles(dungeon.playerPosition, floor),
@@ -49,15 +51,19 @@ export function DungeonGrid({ floor, dungeon, cellSize }: DungeonGridProps) {
       {/* FOE tokens — only render on visible tiles */}
       {dungeon.foes
         .filter((foe) => visibleSet.has(positionKey(foe.position)))
-        .map((foe) => (
-          <FoeToken
-            key={foe.id}
-            cellSize={cellSize}
-            gridX={foe.position.x}
-            gridY={foe.position.y}
-            aggroState={foe.aggroState}
-          />
-        ))}
+        .map((foe) => {
+          const color = getFoeColor(foe.enemyId, partyRoster)
+          return (
+            <FoeToken
+              key={foe.id}
+              cellSize={cellSize}
+              gridX={foe.position.x}
+              gridY={foe.position.y}
+              aggroState={foe.aggroState}
+              color={color}
+            />
+          )
+        })}
 
       {/* Player token (on top) */}
       <PlayerToken

--- a/src/components/dungeon/DungeonScreen.tsx
+++ b/src/components/dungeon/DungeonScreen.tsx
@@ -10,7 +10,10 @@ import { useDirectionInput } from '../../hooks/useDirectionInput'
 // Simple audio notification for FOE aggro
 function playAggroSound() {
   try {
-    const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)()
+    const AudioContextClass = window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!AudioContextClass) return
+
+    const audioContext = new AudioContextClass()
     const oscillator = audioContext.createOscillator()
     const gainNode = audioContext.createGain()
 
@@ -25,7 +28,7 @@ function playAggroSound() {
 
     oscillator.start(audioContext.currentTime)
     oscillator.stop(audioContext.currentTime + 0.2)
-  } catch (e) {
+  } catch {
     // Silently fail if audio context not available
   }
 }

--- a/src/components/dungeon/DungeonScreen.tsx
+++ b/src/components/dungeon/DungeonScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from 'react'
+import { useMemo } from 'react'
 import { useDungeonStore } from '../../stores/dungeonStore'
 import { DungeonViewport } from './DungeonViewport'
 import { DungeonHUD } from './DungeonHUD'
@@ -6,32 +6,6 @@ import { EncounterGauge } from './EncounterGauge'
 import { EventNotification } from './EventNotification'
 import { NavigationPrompt } from './NavigationPrompt'
 import { useDirectionInput } from '../../hooks/useDirectionInput'
-
-// Simple audio notification for FOE aggro
-function playAggroSound() {
-  try {
-    const AudioContextClass = window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
-    if (!AudioContextClass) return
-
-    const audioContext = new AudioContextClass()
-    const oscillator = audioContext.createOscillator()
-    const gainNode = audioContext.createGain()
-
-    oscillator.connect(gainNode)
-    gainNode.connect(audioContext.destination)
-
-    oscillator.frequency.value = 800 // High-pitched alert tone
-    oscillator.type = 'sine'
-
-    gainNode.gain.setValueAtTime(0.3, audioContext.currentTime)
-    gainNode.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + 0.2)
-
-    oscillator.start(audioContext.currentTime)
-    oscillator.stop(audioContext.currentTime + 0.2)
-  } catch {
-    // Silently fail if audio context not available
-  }
-}
 
 export function DungeonScreen() {
   const dungeon = useDungeonStore((s) => s.dungeon)
@@ -61,14 +35,6 @@ export function DungeonScreen() {
   }
 
   useDirectionInput(handleMove)
-
-  // Play audio notification when FOE aggros
-  useEffect(() => {
-    const hasAggroEvent = lastEvents.some((e) => e.type === 'foe-aggro')
-    if (hasAggroEvent) {
-      playAggroSound()
-    }
-  }, [lastEvents])
 
   const handleNextFloor = () => {
     if (!floor?.nextFloorId) return

--- a/src/components/dungeon/FoeToken.tsx
+++ b/src/components/dungeon/FoeToken.tsx
@@ -5,9 +5,16 @@ interface FoeTokenProps {
   gridX: number
   gridY: number
   aggroState: FoeAggroState
+  color: 'red' | 'yellow' | 'green' // Difficulty color based on player power
 }
 
-export function FoeToken({ cellSize, gridX, gridY, aggroState }: FoeTokenProps) {
+const COLOR_MAP = {
+  red: { fill: '#dc2626', stroke: '#991b1b', text: '#fca5a5' },
+  yellow: { fill: '#eab308', stroke: '#a16207', text: '#fef08a' },
+  green: { fill: '#22c55e', stroke: '#15803d', text: '#86efac' },
+}
+
+export function FoeToken({ cellSize, gridX, gridY, aggroState, color }: FoeTokenProps) {
   const half = cellSize / 2
   const pad = cellSize * 0.2
 
@@ -19,6 +26,7 @@ export function FoeToken({ cellSize, gridX, gridY, aggroState }: FoeTokenProps) 
   ].join(' ')
 
   const isAggro = aggroState === 'aggro'
+  const colors = COLOR_MAP[color]
 
   return (
     <svg
@@ -32,8 +40,8 @@ export function FoeToken({ cellSize, gridX, gridY, aggroState }: FoeTokenProps) 
     >
       <polygon
         points={points}
-        fill={isAggro ? '#dc2626' : '#737373'}
-        stroke={isAggro ? '#991b1b' : 'black'}
+        fill={colors.fill}
+        stroke={colors.stroke}
         strokeWidth={isAggro ? 2 : 1.5}
       />
       {isAggro && (
@@ -42,7 +50,7 @@ export function FoeToken({ cellSize, gridX, gridY, aggroState }: FoeTokenProps) 
           y={pad / 2}
           textAnchor="middle"
           fontSize={cellSize * 0.3}
-          fill="#fca5a5"
+          fill={colors.text}
         >
           !
         </text>

--- a/src/components/dungeon/FoeToken.tsx
+++ b/src/components/dungeon/FoeToken.tsx
@@ -1,10 +1,13 @@
+import type { FoeAggroState } from '../../types/dungeon'
+
 interface FoeTokenProps {
   cellSize: number
   gridX: number
   gridY: number
+  aggroState: FoeAggroState
 }
 
-export function FoeToken({ cellSize, gridX, gridY }: FoeTokenProps) {
+export function FoeToken({ cellSize, gridX, gridY, aggroState }: FoeTokenProps) {
   const half = cellSize / 2
   const pad = cellSize * 0.2
 
@@ -15,9 +18,11 @@ export function FoeToken({ cellSize, gridX, gridY }: FoeTokenProps) {
     `${pad},${cellSize - pad}`,
   ].join(' ')
 
+  const isAggro = aggroState === 'aggro'
+
   return (
     <svg
-      className="absolute pointer-events-none"
+      className={`absolute pointer-events-none ${isAggro ? 'animate-pulse' : ''}`}
       style={{
         left: gridX * cellSize,
         top: gridY * cellSize,
@@ -27,10 +32,21 @@ export function FoeToken({ cellSize, gridX, gridY }: FoeTokenProps) {
     >
       <polygon
         points={points}
-        fill="#737373"
-        stroke="black"
-        strokeWidth={1.5}
+        fill={isAggro ? '#dc2626' : '#737373'}
+        stroke={isAggro ? '#991b1b' : 'black'}
+        strokeWidth={isAggro ? 2 : 1.5}
       />
+      {isAggro && (
+        <text
+          x={half}
+          y={pad / 2}
+          textAnchor="middle"
+          fontSize={cellSize * 0.3}
+          fill="#fca5a5"
+        >
+          !
+        </text>
+      )}
     </svg>
   )
 }

--- a/src/components/town/TownScreen.tsx
+++ b/src/components/town/TownScreen.tsx
@@ -39,6 +39,9 @@ export function TownScreen() {
   })
   const newQuestsCount = availableQuests.filter((quest) => !isQuestActive(quest.id)).length
 
+  // Calculate unspent skill points across party
+  const unspentSP = roster.reduce((total, member) => total + member.skillPoints, 0)
+
   return (
     <div className="flex flex-col items-center gap-4 p-6">
       <div className="flex justify-between items-center w-full max-w-half">
@@ -119,8 +122,9 @@ export function TownScreen() {
           className="min-h-touch border-2 border-ink px-4 py-3 font-bold active:bg-ink active:text-paper"
         >
           Quests
-          {claimableQuests > 0 && ` (${claimableQuests})`}
-          {newQuestsCount > 0 && <span className="ml-1">●</span>}
+          {claimableQuests > 0 && newQuestsCount > 0 && ` (${claimableQuests} ready, ${newQuestsCount} new)`}
+          {claimableQuests > 0 && newQuestsCount === 0 && ` (${claimableQuests} ready)`}
+          {claimableQuests === 0 && newQuestsCount > 0 && ` (${newQuestsCount} new)`}
         </button>
 
         <button
@@ -135,6 +139,7 @@ export function TownScreen() {
           className="min-h-touch border-2 border-ink px-4 py-3 font-bold active:bg-ink active:text-paper"
         >
           Characters
+          {unspentSP > 0 && ` (${unspentSP} SP)`}
         </button>
 
         <button

--- a/src/components/ui/GuildNameScreen.tsx
+++ b/src/components/ui/GuildNameScreen.tsx
@@ -21,7 +21,7 @@ export function GuildNameScreen() {
     useGuildStore.getState().setActiveGuild(guild.id, guild.name);
     usePartyStore.getState().initializeRoster();
     useInventoryStore.setState({
-      gold: 100,
+      gold: 0,
       materials: {},
       soldMaterials: {},
       consumables: {},

--- a/src/data/dungeons/floor-1.ts
+++ b/src/data/dungeons/floor-1.ts
@@ -88,12 +88,16 @@ export const FLOOR_1: FloorData = {
         { x: 4, y: 10 },
       ],
       name: 'Thornblob',
+      enemyId: 'thornblob-foe', // Unique FOE enemy (to be created)
+      canPursue: true,
     },
     {
       id: 'foe-f1-stationary',
       position: { x: 10, y: 7 },
       pattern: 'stationary',
       name: 'Guardblob',
+      enemyId: 'guardblob-foe', // Unique FOE enemy (to be created)
+      canPursue: false, // Stationary FOEs don't pursue
     },
   ],
   encounterRate: 8,

--- a/src/data/dungeons/floor-1.ts
+++ b/src/data/dungeons/floor-1.ts
@@ -86,7 +86,8 @@ export const FLOOR_1: FloorData = {
       ],
       name: 'Thornblob',
       enemyId: 'thornblob-foe',
-      canPursue: true, // Chases to teach FOE behavior, but patrol keeps it away from entrance
+      canPursue: true, // Chases to teach FOE behavior
+      detectionRadius: 2, // Reduced from default 3 - can't see entrance from patrol
     },
     {
       id: 'foe-f1-stationary',

--- a/src/data/dungeons/floor-1.ts
+++ b/src/data/dungeons/floor-1.ts
@@ -9,111 +9,144 @@ const C: TileData = { type: 'checkpoint' }
 const S: TileData = { type: 'shortcut' }
 
 /**
- * Verdant Depths — Floor 1
+ * Verdant Depths — Floor 1 (Corridor Redesign)
  *
- * 15x15 grid. Two rooms connected by corridors.
+ * 25x20 grid. Organic winding corridors inspired by Etrian Odyssey V.
+ * FOEs patrol on simple tracks (no pursuit) — teaches timing and "wait & follow" strategies.
  *
  * Layout (W=wall, .=floor, N=entrance, E=exit, C=checkpoint, S=shortcut):
  *
- *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4
- * 0 W W W W W W W W W W W W W W W
- * 1 W . . . . W W W W W . . . . W
- * 2 W . . . . W W W W W . . . . W
- * 3 W . . C . W W W W W . . . . W
- * 4 W . . . . . . . . . . . . . W
- * 5 W W W W . W W W W W . W W W W
- * 6 W W W W . W W W W W . W W W W
- * 7 W W W W . . . . . . . W W W W
- * 8 W W W W . W W W W W . W W W W
- * 9 W W W W . W W W W W . W W W W
- *10 W . . . . . . . . . . . . S W
- *11 W . . . . W W W W W . . . . W
- *12 W . N . . W W W W W . . E . W
- *13 W . . . . W W W W W . . . . W
- *14 W W W W W W W W W W W W W W W
+ *     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4
+ *   0 W W W W W W W W W W W W W W W W W W W W W W W W W
+ *   1 W . . . W W W W W W W W W W W W W W W W . . . . W
+ *   2 W . N . . . W W W W W W W W W W W . . . . C . . W
+ *   3 W . . . W . . . W W W W W W . . . . W . . . . . W
+ *   4 W W W W W W W . . . W W W . . W W W W W W W W . W
+ *   5 W W W W W W W W W . . . . . W W W W W W W W W . W
+ *   6 W W W W W W W W W W W W . . W W W W W W W W . . W
+ *   7 W W W W . . . . . . . . . W W W W W W W W W . W W
+ *   8 W W W W . W W W W W W W . W W W W W W W W W . W W
+ *   9 W W W . . W W W W W W W . . . . . . W W W . . . W
+ *  10 W W W . W W W W W W W W W W W W W . . . . . W . W
+ *  11 W . . . W W W W W W W W W W W W W W W W W . W . W
+ *  12 W . W W W W W W W W W W W W W W W W W W W . W . W
+ *  13 W . W W W W W W W . . . . . . W W W W W . . W . W
+ *  14 W . . . . . . . . . W W W W . . . . . . . W W . W
+ *  15 W W W W W W W W W . W W W W W W W W W W . W W . W
+ *  16 W W W W W W W W W . . . . . . . . . . . . W W . W
+ *  17 W W W W W W W W W W W W W W W W W W W . W W W . W
+ *  18 W . . . . . . . . . . . S . . . . . . . . E . . W
+ *  19 W W W W W W W W W W W W W W W W W W W W W W W W W
+ *
+ * FOE Placement:
+ * - F1 (West): Thornblob at (7,7), vertical 3-tile patrol
+ * - F2 (Central): Elder Slime at (13,9), horizontal 3-tile patrol
+ * - F3 (East): Guardblob at (22,9), vertical 3-tile patrol
+ * - F4 (South): Verdant Patrol at (10,16), horizontal 3-tile patrol
  */
 const tiles: TileData[][] = [
-  // Row 0: all walls
-  [W, W, W, W, W, W, W, W, W, W, W, W, W, W, W],
-  // Row 1: left room top
-  [W, F, F, F, F, W, W, W, W, W, F, F, F, F, W],
-  // Row 2
-  [W, F, F, F, F, W, W, W, W, W, F, F, F, F, W],
-  // Row 3: checkpoint in left room
-  [W, F, F, C, F, W, W, W, W, W, F, F, F, F, W],
-  // Row 4: horizontal corridor connecting rooms
-  [W, F, F, F, F, F, F, F, F, F, F, F, F, F, W],
+  // Row 0: top wall
+  [W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W],
+  // Row 1
+  [W, F, F, F, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, F, F, F, F, W],
+  // Row 2: entrance (2,2), checkpoint (21,2)
+  [W, F, N, F, F, F, W, W, W, W, W, W, W, W, W, W, W, F, F, F, F, C, F, F, W],
+  // Row 3
+  [W, F, F, F, W, F, F, F, W, W, W, W, W, W, F, F, F, F, W, F, F, F, F, F, W],
+  // Row 4
+  [W, W, W, W, W, W, W, F, F, F, W, W, W, F, F, W, W, W, W, W, W, W, W, F, W],
   // Row 5
-  [W, W, W, W, F, W, W, W, W, W, F, W, W, W, W],
+  [W, W, W, W, W, W, W, W, W, F, F, F, F, F, W, W, W, W, W, W, W, W, W, F, W],
   // Row 6
-  [W, W, W, W, F, W, W, W, W, W, F, W, W, W, W],
-  // Row 7: horizontal corridor mid
-  [W, W, W, W, F, F, F, F, F, F, F, W, W, W, W],
+  [W, W, W, W, W, W, W, W, W, W, W, W, F, F, W, W, W, W, W, W, W, W, F, F, W],
+  // Row 7: Thornblob patrol (7,7)→(7,8)→(7,9)
+  [W, W, W, W, F, F, F, F, F, F, F, F, F, W, W, W, W, W, W, W, W, W, F, W, W],
   // Row 8
-  [W, W, W, W, F, W, W, W, W, W, F, W, W, W, W],
-  // Row 9
-  [W, W, W, W, F, W, W, W, W, W, F, W, W, W, W],
-  // Row 10: horizontal corridor bottom connecting rooms
-  [W, F, F, F, F, F, F, F, F, F, F, F, F, S, W],
-  // Row 11: bottom rooms
-  [W, F, F, F, F, W, W, W, W, W, F, F, F, F, W],
-  // Row 12: entrance (left), exit (right)
-  [W, F, N, F, F, W, W, W, W, W, F, F, E, F, W],
+  [W, W, W, W, F, W, W, W, W, W, W, W, F, W, W, W, W, W, W, W, W, W, F, W, W],
+  // Row 9: Mossblob patrol (13,9)→(14,9)→(15,9), Guardblob patrol (22,9)→(22,10)→(22,11)
+  [W, W, W, F, F, W, W, W, W, W, W, W, F, F, F, F, F, F, W, W, W, F, F, F, W],
+  // Row 10
+  [W, W, W, F, W, W, W, W, W, W, W, W, W, W, W, W, W, F, F, F, F, F, W, F, W],
+  // Row 11
+  [W, F, F, F, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, F, W, F, W],
+  // Row 12
+  [W, F, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, F, W, F, W],
   // Row 13
-  [W, F, F, F, F, W, W, W, W, W, F, F, F, F, W],
-  // Row 14: all walls
-  [W, W, W, W, W, W, W, W, W, W, W, W, W, W, W],
+  [W, F, W, W, W, W, W, W, W, F, F, F, F, F, F, W, W, W, W, W, F, F, W, F, W],
+  // Row 14
+  [W, F, F, F, F, F, F, F, F, F, W, W, W, W, F, F, F, F, F, F, F, W, W, F, W],
+  // Row 15
+  [W, W, W, W, W, W, W, W, W, F, W, W, W, W, W, W, W, W, W, W, F, W, W, F, W],
+  // Row 16: Verdant Patrol (10,16)→(11,16)→(12,16)
+  [W, W, W, W, W, W, W, W, W, F, F, F, F, F, F, F, F, F, F, F, F, W, W, F, W],
+  // Row 17
+  [W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, F, W, W, W, F, W],
+  // Row 18: shortcut (12,18), exit (21,18)
+  [W, F, F, F, F, F, F, F, F, F, F, F, S, F, F, F, F, F, F, F, F, E, F, F, W],
+  // Row 19: bottom wall
+  [W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W],
 ]
 
 export const FLOOR_1: FloorData = {
   id: 'verdant-depths-f1',
   dungeonId: 'verdant-depths',
   floorNumber: 1,
-  width: 15,
-  height: 15,
+  width: 25,
+  height: 20,
   tiles,
-  playerStart: { x: 2, y: 12 },
+  playerStart: { x: 2, y: 2 },
   foeSpawns: [
     {
-      id: 'foe-f1-patrol',
-      position: { x: 4, y: 7 },
+      id: 'foe-f1-west-corridor',
+      position: { x: 7, y: 7 },
       pattern: 'patrol',
       patrolPath: [
-        { x: 4, y: 7 },
-        { x: 4, y: 8 },
-        { x: 4, y: 9 },
-        { x: 4, y: 10 },
+        { x: 7, y: 7 },
+        { x: 7, y: 8 },
+        { x: 7, y: 9 },
       ],
       name: 'Thornblob',
       enemyId: 'thornblob-foe',
-      canPursue: true, // Chases to teach FOE behavior
-      detectionRadius: 2, // Reduced from default 3 - can't see entrance from patrol
+      canPursue: false, // EO5-style: no pursuit, teaches timing
     },
     {
-      id: 'foe-f1-stationary',
-      position: { x: 10, y: 7 },
-      pattern: 'stationary',
-      name: 'Guardblob',
-      enemyId: 'guardblob-foe',
-      canPursue: false, // Stationary FOEs don't pursue
-    },
-    {
-      id: 'foe-f1-exit-puzzle',
-      position: { x: 11, y: 11 },
+      id: 'foe-f1-central-junction',
+      position: { x: 13, y: 9 },
       pattern: 'patrol',
       patrolPath: [
-        { x: 11, y: 11 }, // Top-left of loop
-        { x: 12, y: 11 }, // Top-center
-        { x: 13, y: 11 }, // Top-right
-        { x: 13, y: 12 }, // Right-center (blocks exit approach!)
-        { x: 13, y: 13 }, // Bottom-right
-        { x: 12, y: 13 }, // Bottom-center
-        { x: 11, y: 13 }, // Bottom-left
-        { x: 11, y: 12 }, // Left-center
+        { x: 13, y: 9 },
+        { x: 14, y: 9 },
+        { x: 15, y: 9 },
       ],
-      name: 'Verdant Guardian',
+      name: 'Elder Slime',
+      enemyId: 'elder-slime-foe',
+      canPursue: false, // Horizontal corridor patrol
+    },
+    {
+      id: 'foe-f1-east-corridor',
+      position: { x: 22, y: 9 },
+      pattern: 'patrol',
+      patrolPath: [
+        { x: 22, y: 9 },
+        { x: 22, y: 10 },
+        { x: 22, y: 11 },
+      ],
+      name: 'Guardblob',
+      enemyId: 'guardblob-foe',
+      canPursue: false, // Guards checkpoint approach
+    },
+    {
+      id: 'foe-f1-south-corridor',
+      position: { x: 10, y: 16 },
+      pattern: 'patrol',
+      patrolPath: [
+        { x: 10, y: 16 },
+        { x: 11, y: 16 },
+        { x: 12, y: 16 },
+      ],
+      name: 'Verdant Patrol',
       enemyId: 'verdant-guardian-foe',
-      canPursue: false, // Puzzle FOE - stays on patrol loop forever!
+      canPursue: false, // Guards shortcut/exit area
     },
   ],
   encounterRate: 8,

--- a/src/data/dungeons/floor-1.ts
+++ b/src/data/dungeons/floor-1.ts
@@ -76,12 +76,9 @@ export const FLOOR_1: FloorData = {
   foeSpawns: [
     {
       id: 'foe-f1-patrol',
-      position: { x: 4, y: 5 },
+      position: { x: 4, y: 7 },
       pattern: 'patrol',
       patrolPath: [
-        { x: 4, y: 4 },
-        { x: 4, y: 5 },
-        { x: 4, y: 6 },
         { x: 4, y: 7 },
         { x: 4, y: 8 },
         { x: 4, y: 9 },
@@ -89,7 +86,7 @@ export const FLOOR_1: FloorData = {
       ],
       name: 'Thornblob',
       enemyId: 'thornblob-foe',
-      canPursue: true,
+      canPursue: true, // Chases to teach FOE behavior, but patrol keeps it away from entrance
     },
     {
       id: 'foe-f1-stationary',

--- a/src/data/dungeons/floor-1.ts
+++ b/src/data/dungeons/floor-1.ts
@@ -104,8 +104,8 @@ export const FLOOR_1: FloorData = {
       { enemyId: 'mossy-slime', weight: 1 },
     ],
     foe: [
-      { enemyId: 'slime', weight: 2 },
-      { enemyId: 'mossy-slime', weight: 2 },
+      { enemyId: 'elite-slime', weight: 3 },
+      { enemyId: 'elite-mossy-slime', weight: 2 },
     ],
     randomSize: [1, 2],
     foeSize: [2, 3],

--- a/src/data/dungeons/floor-1.ts
+++ b/src/data/dungeons/floor-1.ts
@@ -88,7 +88,7 @@ export const FLOOR_1: FloorData = {
         { x: 4, y: 10 },
       ],
       name: 'Thornblob',
-      enemyId: 'thornblob-foe', // Unique FOE enemy (to be created)
+      enemyId: 'thornblob-foe',
       canPursue: true,
     },
     {
@@ -96,8 +96,26 @@ export const FLOOR_1: FloorData = {
       position: { x: 10, y: 7 },
       pattern: 'stationary',
       name: 'Guardblob',
-      enemyId: 'guardblob-foe', // Unique FOE enemy (to be created)
+      enemyId: 'guardblob-foe',
       canPursue: false, // Stationary FOEs don't pursue
+    },
+    {
+      id: 'foe-f1-exit-puzzle',
+      position: { x: 11, y: 11 },
+      pattern: 'patrol',
+      patrolPath: [
+        { x: 11, y: 11 }, // Top-left of loop
+        { x: 12, y: 11 }, // Top-center
+        { x: 13, y: 11 }, // Top-right
+        { x: 13, y: 12 }, // Right-center (blocks exit approach!)
+        { x: 13, y: 13 }, // Bottom-right
+        { x: 12, y: 13 }, // Bottom-center
+        { x: 11, y: 13 }, // Bottom-left
+        { x: 11, y: 12 }, // Left-center
+      ],
+      name: 'Verdant Guardian',
+      enemyId: 'verdant-guardian-foe',
+      canPursue: false, // Puzzle FOE - stays on patrol loop forever!
     },
   ],
   encounterRate: 8,

--- a/src/data/dungeons/floor-2.ts
+++ b/src/data/dungeons/floor-2.ts
@@ -86,6 +86,8 @@ export const FLOOR_2: FloorData = {
       position: { x: 7, y: 7 },
       pattern: 'chase',
       name: 'Venomblob',
+      enemyId: 'venomblob-foe', // Unique FOE enemy (to be created)
+      canPursue: true,
     },
   ],
   encounterRate: 6,

--- a/src/data/dungeons/floor-2.ts
+++ b/src/data/dungeons/floor-2.ts
@@ -97,8 +97,9 @@ export const FLOOR_2: FloorData = {
       { enemyId: 'mossy-slime', weight: 1 },
     ],
     foe: [
-      { enemyId: 'fungoid', weight: 2 },
-      { enemyId: 'sporebat', weight: 2 },
+      { enemyId: 'elite-fungoid', weight: 3 },
+      { enemyId: 'elite-mossy-slime', weight: 1 },
+      { enemyId: 'sporebat', weight: 1 },
     ],
     randomSize: [2, 3],
     foeSize: [2, 3],

--- a/src/data/dungeons/floor-3.ts
+++ b/src/data/dungeons/floor-3.ts
@@ -91,6 +91,8 @@ export const FLOOR_3: FloorData = {
       position: { x: 8, y: 9 },
       pattern: 'stationary',
       name: 'Elder Slime',
+      enemyId: 'elder-slime-foe', // Unique FOE enemy (to be created)
+      canPursue: false, // Boss-type stationary FOE
     },
   ],
   encounterRate: 5,

--- a/src/data/dungeons/floor-3.ts
+++ b/src/data/dungeons/floor-3.ts
@@ -102,8 +102,8 @@ export const FLOOR_3: FloorData = {
       { enemyId: 'sporebat', weight: 1 },
     ],
     foe: [
-      { enemyId: 'crystal-beetle', weight: 2 },
-      { enemyId: 'caveworm', weight: 2 },
+      { enemyId: 'elite-crystal-beetle', weight: 3 },
+      { enemyId: 'elite-caveworm', weight: 2 },
     ],
     randomSize: [2, 4],
     foeSize: [3, 4],

--- a/src/data/enemies/elder-slime-foe.ts
+++ b/src/data/enemies/elder-slime-foe.ts
@@ -1,0 +1,42 @@
+/**
+ * Elder Slime FOE - Floor 3 Boss
+ *
+ * An ancient, massive slime of immense power. The guardian of the deep floors.
+ * Well-rounded boss with high stats and diverse skill set.
+ */
+
+import type { EnemyDefinition } from '../../types/combat';
+
+export const ENEMY_ELDER_SLIME_FOE: EnemyDefinition = {
+  id: 'elder-slime-foe',
+  name: 'Elder Slime',
+  stats: {
+    str: 22,
+    vit: 20,
+    int: 20,
+    wis: 18,
+    agi: 16,
+    luc: 15,
+  },
+  maxHp: 250,
+  maxTp: 80,
+  skills: [
+    'slime-acid-splash',
+    'slime-sticky-slap',
+    'arm-bind-basic',
+    'leg-bind-basic',
+    'poison-cloud',
+    'push-back',
+  ],
+  aiPattern: 'defensive',
+  dropTable: {
+    materials: [
+      { materialId: 'ancient-core', chance: 1.0 },
+      { materialId: 'elder-essence', chance: 0.8 },
+      { materialId: 'slime-core', chance: 0.9 },
+      { materialId: 'slime-gel', chance: 1.0 },
+    ],
+    xp: 300,
+    gold: { min: 150, max: 250 },
+  },
+};

--- a/src/data/enemies/elite-caveworm.ts
+++ b/src/data/enemies/elite-caveworm.ts
@@ -1,0 +1,33 @@
+/**
+ * Elite Caveworm Enemy Definition
+ *
+ * FOE-exclusive variant. High-damage physical attacker with bind.
+ * 2x HP, +30% stats, enhanced constrict skill.
+ */
+
+import type { EnemyDefinition } from '../../types/combat'
+
+export const ENEMY_ELITE_CAVEWORM: EnemyDefinition = {
+  id: 'elite-caveworm',
+  name: 'Elite Caveworm',
+  stats: {
+    str: 18, // +30% from 14
+    vit: 9, // +30% from 7
+    int: 4, // +30% from 3
+    wis: 5, // +30% from 4
+    agi: 7, // +30% from 5
+    luc: 5, // +30% from 4
+  },
+  maxHp: 90, // 2x caveworm (45 -> 90)
+  maxTp: 20,
+  skills: ['burrow-strike', 'constrict', 'arm-bind-basic'],
+  aiPattern: 'aggressive',
+  dropTable: {
+    materials: [
+      { materialId: 'tough-carapace', chance: 0.7 },
+      { materialId: 'venomous-fang', chance: 0.3 },
+    ],
+    xp: 70,
+    gold: { min: 25, max: 45 },
+  },
+}

--- a/src/data/enemies/elite-crystal-beetle.ts
+++ b/src/data/enemies/elite-crystal-beetle.ts
@@ -1,0 +1,33 @@
+/**
+ * Elite Crystal Beetle Enemy Definition
+ *
+ * FOE-exclusive variant. Ultra-defensive tank with displacement.
+ * 2x HP, +30% stats, enhanced shell guard.
+ */
+
+import type { EnemyDefinition } from '../../types/combat'
+
+export const ENEMY_ELITE_CRYSTAL_BEETLE: EnemyDefinition = {
+  id: 'elite-crystal-beetle',
+  name: 'Elite Crystal Beetle',
+  stats: {
+    str: 13, // +30% from 10
+    vit: 16, // +30% from 12
+    int: 4, // +30% from 3
+    wis: 7, // +30% from 5
+    agi: 5, // +30% from 4
+    luc: 7, // +30% from 5
+  },
+  maxHp: 100, // 2x crystal beetle (50 -> 100)
+  maxTp: 20,
+  skills: ['shell-guard', 'horn-charge', 'push-back'],
+  aiPattern: 'defensive',
+  dropTable: {
+    materials: [
+      { materialId: 'crystal-shard', chance: 0.7 },
+      { materialId: 'pristine-shell', chance: 0.3 },
+    ],
+    xp: 80,
+    gold: { min: 30, max: 50 },
+  },
+}

--- a/src/data/enemies/elite-fungoid.ts
+++ b/src/data/enemies/elite-fungoid.ts
@@ -1,0 +1,33 @@
+/**
+ * Elite Fungoid Enemy Definition
+ *
+ * FOE-exclusive variant. Support/debuffer with paralysis and poison.
+ * 2x HP, +30% stats, enhanced ailment skills.
+ */
+
+import type { EnemyDefinition } from '../../types/combat'
+
+export const ENEMY_ELITE_FUNGOID: EnemyDefinition = {
+  id: 'elite-fungoid',
+  name: 'Elite Fungoid',
+  stats: {
+    str: 6, // +30% from ~5
+    vit: 8, // +30% from ~6
+    int: 10, // +30% from ~8
+    wis: 10, // +30% from ~8
+    agi: 5, // +30% from ~4
+    luc: 8, // +30% from ~6
+  },
+  maxHp: 70, // 2x estimated base (~35 -> 70)
+  maxTp: 30,
+  skills: ['fungal-spores', 'paralyzing-pollen', 'poison-cloud'],
+  aiPattern: 'defensive',
+  dropTable: {
+    materials: [
+      { materialId: 'fungal-spores', chance: 0.7 },
+      { materialId: 'toxic-cap', chance: 0.4 },
+    ],
+    xp: 45,
+    gold: { min: 18, max: 32 },
+  },
+}

--- a/src/data/enemies/elite-mossy-slime.ts
+++ b/src/data/enemies/elite-mossy-slime.ts
@@ -1,0 +1,33 @@
+/**
+ * Elite Mossy Slime Enemy Definition
+ *
+ * FOE-exclusive variant. Defensive tank with high VIT and self-buff.
+ * 2x HP, +30% stats, enhanced shield skill.
+ */
+
+import type { EnemyDefinition } from '../../types/combat'
+
+export const ENEMY_ELITE_MOSSY_SLIME: EnemyDefinition = {
+  id: 'elite-mossy-slime',
+  name: 'Elite Mossy Slime',
+  stats: {
+    str: 8, // +30% from 6
+    vit: 11, // +30% from 8
+    int: 5, // +30% from 4
+    wis: 7, // +30% from 5
+    agi: 5, // +30% from 4
+    luc: 5, // +30% from 4
+  },
+  maxHp: 80, // 2x standard mossy slime (40 -> 80)
+  maxTp: 25,
+  skills: ['mossy-shield', 'slime-acid-splash', 'arm-bind-basic'],
+  aiPattern: 'defensive',
+  dropTable: {
+    materials: [
+      { materialId: 'slime-gel', chance: 0.7 },
+      { materialId: 'slime-core', chance: 0.5 },
+    ],
+    xp: 50,
+    gold: { min: 20, max: 35 },
+  },
+}

--- a/src/data/enemies/elite-slime.ts
+++ b/src/data/enemies/elite-slime.ts
@@ -1,0 +1,33 @@
+/**
+ * Elite Slime Enemy Definition
+ *
+ * FOE-exclusive variant. Significantly tougher than standard slime.
+ * 2x HP, +30% stats, access to bind skills.
+ */
+
+import type { EnemyDefinition } from '../../types/combat'
+
+export const ENEMY_ELITE_SLIME: EnemyDefinition = {
+  id: 'elite-slime',
+  name: 'Elite Slime',
+  stats: {
+    str: 11, // +30% from 8
+    vit: 7, // +30% from 5
+    int: 4, // +30% from 3
+    wis: 5, // +30% from 4
+    agi: 8, // +30% from 6
+    luc: 7, // +30% from 5
+  },
+  maxHp: 60, // 2x standard slime (30 -> 60)
+  maxTp: 20,
+  skills: ['slime-acid-splash', 'slime-sticky-slap', 'leg-bind-basic'],
+  aiPattern: 'aggressive',
+  dropTable: {
+    materials: [
+      { materialId: 'slime-gel', chance: 0.8 },
+      { materialId: 'slime-core', chance: 0.4 },
+    ],
+    xp: 40,
+    gold: { min: 15, max: 30 },
+  },
+}

--- a/src/data/enemies/guardblob-foe.ts
+++ b/src/data/enemies/guardblob-foe.ts
@@ -1,0 +1,37 @@
+/**
+ * Guardblob FOE - Floor 1 Stationary
+ *
+ * A fortified blob with hardened exterior. Guards a specific location.
+ * Defensive tank that buffs itself and has high VIT.
+ */
+
+import type { EnemyDefinition } from '../../types/combat';
+
+export const ENEMY_GUARDBLOB_FOE: EnemyDefinition = {
+  id: 'guardblob-foe',
+  name: 'Guardblob',
+  stats: {
+    str: 15,
+    vit: 20,
+    int: 8,
+    wis: 12,
+    agi: 8,
+    luc: 10,
+  },
+  maxHp: 150,
+  maxTp: 35,
+  skills: [
+    'slime-acid-splash',
+    'mossy-shield', // Self-buff for VIT
+  ],
+  aiPattern: 'defensive',
+  dropTable: {
+    materials: [
+      { materialId: 'hardened-gel', chance: 0.8 },
+      { materialId: 'slime-core', chance: 0.4 },
+      { materialId: 'slime-gel', chance: 0.6 },
+    ],
+    xp: 90,
+    gold: { min: 40, max: 70 },
+  },
+};

--- a/src/data/enemies/index.ts
+++ b/src/data/enemies/index.ts
@@ -14,6 +14,10 @@ import { ENEMY_ELITE_MOSSY_SLIME } from './elite-mossy-slime';
 import { ENEMY_ELITE_FUNGOID } from './elite-fungoid';
 import { ENEMY_ELITE_CRYSTAL_BEETLE } from './elite-crystal-beetle';
 import { ENEMY_ELITE_CAVEWORM } from './elite-caveworm';
+import { ENEMY_THORNBLOB_FOE } from './thornblob-foe';
+import { ENEMY_GUARDBLOB_FOE } from './guardblob-foe';
+import { ENEMY_VENOMBLOB_FOE } from './venomblob-foe';
+import { ENEMY_ELDER_SLIME_FOE } from './elder-slime-foe';
 
 const ALL_ENEMIES: EnemyDefinition[] = [
   ENEMY_SLIME,
@@ -27,6 +31,10 @@ const ALL_ENEMIES: EnemyDefinition[] = [
   ENEMY_ELITE_FUNGOID,
   ENEMY_ELITE_CRYSTAL_BEETLE,
   ENEMY_ELITE_CAVEWORM,
+  ENEMY_THORNBLOB_FOE,
+  ENEMY_GUARDBLOB_FOE,
+  ENEMY_VENOMBLOB_FOE,
+  ENEMY_ELDER_SLIME_FOE,
 ];
 
 const ENEMY_REGISTRY: Record<string, EnemyDefinition> = {};

--- a/src/data/enemies/index.ts
+++ b/src/data/enemies/index.ts
@@ -9,6 +9,11 @@ import { ENEMY_FUNGOID } from './fungoid';
 import { ENEMY_SPOREBAT } from './sporebat';
 import { ENEMY_CRYSTAL_BEETLE } from './crystal-beetle';
 import { ENEMY_CAVEWORM } from './caveworm';
+import { ENEMY_ELITE_SLIME } from './elite-slime';
+import { ENEMY_ELITE_MOSSY_SLIME } from './elite-mossy-slime';
+import { ENEMY_ELITE_FUNGOID } from './elite-fungoid';
+import { ENEMY_ELITE_CRYSTAL_BEETLE } from './elite-crystal-beetle';
+import { ENEMY_ELITE_CAVEWORM } from './elite-caveworm';
 
 const ALL_ENEMIES: EnemyDefinition[] = [
   ENEMY_SLIME,
@@ -17,6 +22,11 @@ const ALL_ENEMIES: EnemyDefinition[] = [
   ENEMY_SPOREBAT,
   ENEMY_CRYSTAL_BEETLE,
   ENEMY_CAVEWORM,
+  ENEMY_ELITE_SLIME,
+  ENEMY_ELITE_MOSSY_SLIME,
+  ENEMY_ELITE_FUNGOID,
+  ENEMY_ELITE_CRYSTAL_BEETLE,
+  ENEMY_ELITE_CAVEWORM,
 ];
 
 const ENEMY_REGISTRY: Record<string, EnemyDefinition> = {};

--- a/src/data/enemies/index.ts
+++ b/src/data/enemies/index.ts
@@ -18,6 +18,7 @@ import { ENEMY_THORNBLOB_FOE } from './thornblob-foe';
 import { ENEMY_GUARDBLOB_FOE } from './guardblob-foe';
 import { ENEMY_VENOMBLOB_FOE } from './venomblob-foe';
 import { ENEMY_ELDER_SLIME_FOE } from './elder-slime-foe';
+import { ENEMY_VERDANT_GUARDIAN_FOE } from './verdant-guardian-foe';
 
 const ALL_ENEMIES: EnemyDefinition[] = [
   ENEMY_SLIME,
@@ -35,6 +36,7 @@ const ALL_ENEMIES: EnemyDefinition[] = [
   ENEMY_GUARDBLOB_FOE,
   ENEMY_VENOMBLOB_FOE,
   ENEMY_ELDER_SLIME_FOE,
+  ENEMY_VERDANT_GUARDIAN_FOE,
 ];
 
 const ENEMY_REGISTRY: Record<string, EnemyDefinition> = {};

--- a/src/data/enemies/thornblob-foe.ts
+++ b/src/data/enemies/thornblob-foe.ts
@@ -1,0 +1,39 @@
+/**
+ * Thornblob FOE - Floor 1 Patrol
+ *
+ * A unique spiky blob covered in thorns. Patrols the first floor corridors.
+ * Physical attacker that can bind limbs with its thorny tendrils.
+ */
+
+import type { EnemyDefinition } from '../../types/combat';
+
+export const ENEMY_THORNBLOB_FOE: EnemyDefinition = {
+  id: 'thornblob-foe',
+  name: 'Thornblob',
+  stats: {
+    str: 18,
+    vit: 14,
+    int: 8,
+    wis: 10,
+    agi: 12,
+    luc: 8,
+  },
+  maxHp: 120,
+  maxTp: 30,
+  skills: [
+    'slime-acid-splash',
+    'slime-sticky-slap',
+    'leg-bind-basic',
+    'arm-bind-basic',
+  ],
+  aiPattern: 'aggressive',
+  dropTable: {
+    materials: [
+      { materialId: 'thorn-fragment', chance: 0.8 },
+      { materialId: 'slime-gel', chance: 0.5 },
+      { materialId: 'slime-core', chance: 0.3 },
+    ],
+    xp: 80,
+    gold: { min: 30, max: 60 },
+  },
+};

--- a/src/data/enemies/venomblob-foe.ts
+++ b/src/data/enemies/venomblob-foe.ts
@@ -1,0 +1,38 @@
+/**
+ * Venomblob FOE - Floor 2 Chase
+ *
+ * A toxic blob that secretes deadly poison. Aggressively chases intruders.
+ * Poison specialist with multiple ailment skills.
+ */
+
+import type { EnemyDefinition } from '../../types/combat';
+
+export const ENEMY_VENOMBLOB_FOE: EnemyDefinition = {
+  id: 'venomblob-foe',
+  name: 'Venomblob',
+  stats: {
+    str: 16,
+    vit: 15,
+    int: 18,
+    wis: 14,
+    agi: 14,
+    luc: 12,
+  },
+  maxHp: 140,
+  maxTp: 50,
+  skills: [
+    'slime-acid-splash',
+    'poison-cloud',
+    'paralyzing-pollen',
+  ],
+  aiPattern: 'aggressive',
+  dropTable: {
+    materials: [
+      { materialId: 'venom-sac', chance: 0.9 },
+      { materialId: 'toxic-gel', chance: 0.7 },
+      { materialId: 'slime-core', chance: 0.4 },
+    ],
+    xp: 150,
+    gold: { min: 60, max: 100 },
+  },
+};

--- a/src/data/enemies/verdant-guardian-foe.ts
+++ b/src/data/enemies/verdant-guardian-foe.ts
@@ -1,0 +1,41 @@
+/**
+ * Verdant Guardian FOE - Floor 1 Exit Puzzle
+ *
+ * An ancient guardian that patrols the exit corridor. Blocks access to the stairs.
+ * Mixed attacker with defensive capabilities and bind skills.
+ * This FOE never pursues (canPursue: false) - stays on patrol loop forever.
+ */
+
+import type { EnemyDefinition } from '../../types/combat';
+
+export const ENEMY_VERDANT_GUARDIAN_FOE: EnemyDefinition = {
+  id: 'verdant-guardian-foe',
+  name: 'Verdant Guardian',
+  stats: {
+    str: 16,
+    vit: 18,
+    int: 12,
+    wis: 14,
+    agi: 10,
+    luc: 12,
+  },
+  maxHp: 140,
+  maxTp: 40,
+  skills: [
+    'slime-acid-splash',
+    'slime-sticky-slap',
+    'mossy-shield', // Self-buff for defense
+    'leg-bind-basic', // Can bind legs to prevent escape
+  ],
+  aiPattern: 'defensive',
+  dropTable: {
+    materials: [
+      { materialId: 'verdant-core', chance: 0.9 },
+      { materialId: 'ancient-moss', chance: 0.7 },
+      { materialId: 'slime-core', chance: 0.5 },
+      { materialId: 'slime-gel', chance: 0.6 },
+    ],
+    xp: 120,
+    gold: { min: 50, max: 90 },
+  },
+};

--- a/src/data/help/dungeon.ts
+++ b/src/data/help/dungeon.ts
@@ -7,7 +7,7 @@ export const DUNGEON_SECTIONS: HelpEntry[] = [
   },
   {
     heading: 'FOEs (Field On Enemy)',
-    body: 'FOEs are powerful enemies visible on the dungeon map. They are much tougher than random encounters and are meant to be avoided early on.\n\nFOEs move one step each time you move. Each FOE has a movement pattern — some patrol, some chase, and some stand still until provoked. Colliding with a FOE starts a difficult battle.',
+    body: 'FOEs are powerful enemies visible on the dungeon map. They are much tougher than random encounters and are meant to be avoided early on.\n\nFOEs move one step each time you move. Each FOE has a movement pattern — some patrol, some chase, and some stand still until provoked.\n\nDetection & Aggro: When you enter a FOE\'s detection radius (typically 3 tiles) and are in its line of sight, the FOE will notice you. An aggro\'d FOE turns red and plays an alert sound. Patrol FOEs switch to chase behavior when aggro\'d.\n\nTo escape an aggro\'d FOE, move far enough away (beyond detection radius + 2 tiles) or transition to a different area. Colliding with a FOE starts a difficult battle with elite enemies and no retreat.',
   },
   {
     heading: 'Fog of War',

--- a/src/stores/inventoryStore.ts
+++ b/src/stores/inventoryStore.ts
@@ -53,7 +53,7 @@ interface InventoryStore {
 }
 
 const INITIAL_STATE = {
-  gold: 100,
+  gold: 0,
   materials: {} as Record<string, number>,
   soldMaterials: {} as Record<string, number>,
   consumables: {} as Record<string, number>,

--- a/src/systems/dungeon.test.ts
+++ b/src/systems/dungeon.test.ts
@@ -27,6 +27,21 @@ import {
 
 // ---- Test helpers ----
 
+/** Helper to create test FOE with default required fields */
+function makeFoe(overrides: Partial<FoeState> = {}): FoeState {
+  return {
+    id: 'foe-1',
+    position: { x: 0, y: 0 },
+    pattern: 'patrol',
+    patrolIndex: 0,
+    patrolDirection: 1,
+    name: 'Test FOE',
+    detectionRadius: 3,
+    aggroState: 'patrol',
+    ...overrides,
+  }
+}
+
 /** Minimal 3x3 floor for testing */
 function makeFloor(overrides?: Partial<FloorData>): FloorData {
   // . . .
@@ -399,30 +414,23 @@ describe('movePatrolFoe', () => {
   ]
 
   it('advances along patrol path', () => {
-    const foe: FoeState = {
-      id: 'foe-1',
+    const foe = makeFoe({
       position: path[0],
       pattern: 'patrol',
       patrolPath: path,
-      patrolIndex: 0,
-      patrolDirection: 1,
-      name: 'Test FOE',
-    }
+    })
     const result = movePatrolFoe(foe)
     expect(result.position).toEqual({ x: 1, y: 1 })
     expect(result.patrolIndex).toBe(1)
   })
 
   it('reverses at the end of the path', () => {
-    const foe: FoeState = {
-      id: 'foe-1',
+    const foe = makeFoe({
       position: path[2],
       pattern: 'patrol',
       patrolPath: path,
       patrolIndex: 2,
-      patrolDirection: 1,
-      name: 'Test FOE',
-    }
+    })
     const result = movePatrolFoe(foe)
     expect(result.position).toEqual({ x: 1, y: 1 })
     expect(result.patrolIndex).toBe(1)
@@ -430,15 +438,12 @@ describe('movePatrolFoe', () => {
   })
 
   it('reverses at the start of the path', () => {
-    const foe: FoeState = {
-      id: 'foe-1',
+    const foe = makeFoe({
       position: path[0],
       pattern: 'patrol',
       patrolPath: path,
-      patrolIndex: 0,
       patrolDirection: -1,
-      name: 'Test FOE',
-    }
+    })
     const result = movePatrolFoe(foe)
     expect(result.position).toEqual({ x: 1, y: 1 })
     expect(result.patrolIndex).toBe(1)
@@ -446,14 +451,7 @@ describe('movePatrolFoe', () => {
   })
 
   it('returns unchanged foe if no patrol path', () => {
-    const foe: FoeState = {
-      id: 'foe-1',
-      position: { x: 0, y: 0 },
-      pattern: 'patrol',
-      patrolIndex: 0,
-      patrolDirection: 1,
-      name: 'Test FOE',
-    }
+    const foe = makeFoe()
     expect(movePatrolFoe(foe)).toEqual(foe)
   })
 })
@@ -461,14 +459,11 @@ describe('movePatrolFoe', () => {
 describe('moveChaseFoe', () => {
   it('moves toward the player on the primary axis', () => {
     const floor = makeFloor()
-    const foe: FoeState = {
-      id: 'foe-1',
+    const foe = makeFoe({
       position: { x: 0, y: 0 },
       pattern: 'chase',
-      patrolIndex: 0,
-      patrolDirection: 1,
       name: 'Chaser',
-    }
+    })
     const result = moveChaseFoe(foe, { x: 2, y: 2 }, floor)
     // Larger or equal dx, so moves east
     expect(result.position).toEqual({ x: 1, y: 0 })
@@ -476,14 +471,11 @@ describe('moveChaseFoe', () => {
 
   it('does not move if already on the player', () => {
     const floor = makeFloor()
-    const foe: FoeState = {
-      id: 'foe-1',
+    const foe = makeFoe({
       position: { x: 1, y: 1 },
       pattern: 'chase',
-      patrolIndex: 0,
-      patrolDirection: 1,
       name: 'Chaser',
-    }
+    })
     const result = moveChaseFoe(foe, { x: 1, y: 1 }, floor)
     expect(result.position).toEqual({ x: 1, y: 1 })
   })
@@ -498,14 +490,11 @@ describe('moveChaseFoe', () => {
         [{ type: 'floor' }, { type: 'floor' }, { type: 'floor' }],
       ],
     })
-    const foe: FoeState = {
-      id: 'foe-1',
+    const foe = makeFoe({
       position: { x: 1, y: 2 },
       pattern: 'chase',
-      patrolIndex: 0,
-      patrolDirection: 1,
       name: 'Chaser',
-    }
+    })
     const result = moveChaseFoe(foe, { x: 2, y: 0 }, floor)
     // Can't go north (wall), tries east
     expect(result.position).toEqual({ x: 2, y: 2 })
@@ -518,23 +507,18 @@ describe('moveFoes', () => {
     const state = makeState({
       playerPosition: { x: 0, y: 0 },
       foes: [
-        {
+        makeFoe({
           id: 'patrol',
           position: { x: 1, y: 0 },
-          pattern: 'patrol',
           patrolPath: [{ x: 1, y: 0 }, { x: 1, y: 1 }],
-          patrolIndex: 0,
-          patrolDirection: 1,
           name: 'Patrol',
-        },
-        {
+        }),
+        makeFoe({
           id: 'stationary',
           position: { x: 2, y: 0 },
           pattern: 'stationary',
-          patrolIndex: 0,
-          patrolDirection: 1,
           name: 'Guard',
-        },
+        }),
       ],
     })
     const result = moveFoes(state, floor)
@@ -549,14 +533,11 @@ describe('checkFoeCollision', () => {
   it('returns foe id when on same tile as player', () => {
     const state = makeState({
       playerPosition: { x: 1, y: 1 },
-      foes: [{
-        id: 'foe-1',
+      foes: [makeFoe({
         position: { x: 1, y: 1 },
         pattern: 'stationary',
-        patrolIndex: 0,
-        patrolDirection: 1,
         name: 'Guard',
-      }],
+      })],
     })
     expect(checkFoeCollision(state)).toBe('foe-1')
   })
@@ -564,14 +545,11 @@ describe('checkFoeCollision', () => {
   it('returns null when no collision', () => {
     const state = makeState({
       playerPosition: { x: 0, y: 0 },
-      foes: [{
-        id: 'foe-1',
+      foes: [makeFoe({
         position: { x: 2, y: 2 },
         pattern: 'stationary',
-        patrolIndex: 0,
-        patrolDirection: 1,
         name: 'Guard',
-      }],
+      })],
     })
     expect(checkFoeCollision(state)).toBeNull()
   })
@@ -676,14 +654,11 @@ describe('processTurn', () => {
     const floor = makeFloor()
     const state = makeState({
       playerPosition: { x: 0, y: 0 },
-      foes: [{
-        id: 'foe-1',
+      foes: [makeFoe({
         position: { x: 1, y: 0 },
         pattern: 'stationary',
-        patrolIndex: 0,
-        patrolDirection: 1,
         name: 'Guard',
-      }],
+      })],
     })
     const result = processTurn(state, floor, 'east', () => 0)
     expect(result.events).toContainEqual({ type: 'foe-collision', foeId: 'foe-1' })
@@ -706,15 +681,12 @@ describe('processTurn', () => {
     const floor = makeFloor()
     const state = makeState({
       playerPosition: { x: 0, y: 0 },
-      foes: [{
+      foes: [makeFoe({
         id: 'patrol',
         position: { x: 2, y: 0 },
-        pattern: 'patrol',
         patrolPath: [{ x: 2, y: 0 }, { x: 2, y: 1 }],
-        patrolIndex: 0,
-        patrolDirection: 1,
         name: 'Patrol',
-      }],
+      })],
     })
     const result = processTurn(state, floor, 'south', () => 0)
     expect(result.state.foes[0].position).toEqual({ x: 2, y: 1 })

--- a/src/systems/dungeon.test.ts
+++ b/src/systems/dungeon.test.ts
@@ -38,6 +38,8 @@ function makeFoe(overrides: Partial<FoeState> = {}): FoeState {
     name: 'Test FOE',
     detectionRadius: 3,
     aggroState: 'patrol',
+    canPursue: true,
+    enemyId: 'test-foe-enemy',
     ...overrides,
   }
 }
@@ -707,6 +709,7 @@ describe('initializeDungeonState', () => {
         pattern: 'patrol',
         patrolPath: [{ x: 2, y: 0 }, { x: 2, y: 1 }],
         name: 'Patrol FOE',
+        enemyId: 'test-foe-enemy',
       }],
     })
 

--- a/src/systems/dungeon.test.ts
+++ b/src/systems/dungeon.test.ts
@@ -569,11 +569,17 @@ describe('tickEncounterGauge', () => {
     expect(result.triggered).toBe(false)
   })
 
-  it('triggers at threshold and resets to 0', () => {
+  it('has 25% chance to trigger at threshold', () => {
     const gauge = { value: 91, threshold: 100 }
-    const result = tickEncounterGauge(gauge, floor)
-    expect(result.triggered).toBe(true)
-    expect(result.gauge.value).toBe(0)
+    // Test with low RNG value (< 0.25) - should trigger
+    const resultTrigger = tickEncounterGauge(gauge, floor, () => 0.1)
+    expect(resultTrigger.triggered).toBe(true)
+    expect(resultTrigger.gauge.value).toBe(0) // resets when triggered
+
+    // Test with high RNG value (>= 0.25) - should NOT trigger
+    const resultNoTrigger = tickEncounterGauge(gauge, floor, () => 0.5)
+    expect(resultNoTrigger.triggered).toBe(false)
+    expect(resultNoTrigger.gauge.value).toBe(100) // stays at threshold (red zone)
   })
 
   it('uses variance from rng', () => {
@@ -587,11 +593,12 @@ describe('tickEncounterGauge', () => {
     expect(result.gauge.value).toBe(20)
   })
 
-  it('caps value at threshold', () => {
+  it('stays at threshold when in red zone and no trigger', () => {
     const gauge = { value: 95, threshold: 100 }
-    const result = tickEncounterGauge(gauge, floor)
-    expect(result.gauge.value).toBe(0) // triggered and reset
-    expect(result.triggered).toBe(true)
+    // High RNG (>= 0.25) = no trigger, stays in red
+    const result = tickEncounterGauge(gauge, floor, () => 0.9)
+    expect(result.gauge.value).toBe(100) // stays at threshold
+    expect(result.triggered).toBe(false)
   })
 })
 

--- a/src/systems/dungeon.ts
+++ b/src/systems/dungeon.ts
@@ -287,9 +287,9 @@ export function moveFoes(
   floor: FloorData,
 ): DungeonState {
   const newFoes = state.foes.map((foe) => {
-    // Patrol FOEs switch to chase when aggro'd
+    // Patrol FOEs switch to chase when aggro'd (only if canPursue is true)
     const effectivePattern =
-      foe.pattern === 'patrol' && foe.aggroState === 'aggro'
+      foe.pattern === 'patrol' && foe.aggroState === 'aggro' && foe.canPursue
         ? 'chase'
         : foe.pattern
 
@@ -343,8 +343,8 @@ export function updateFoeAggro(
     const canDetect = canFoeDetectPlayer(foe, playerPos, floor)
     const dist = distance(foe.position, playerPos)
 
-    // Trigger aggro if detected and not already aggro'd
-    if (canDetect && foe.aggroState === 'patrol') {
+    // Trigger aggro if detected, not already aggro'd, and FOE can pursue
+    if (canDetect && foe.aggroState === 'patrol' && foe.canPursue) {
       newlyAggrod.push(foe.id)
       return { ...foe, aggroState: 'aggro' as const }
     }
@@ -543,6 +543,8 @@ export function initializeDungeonState(
       name: spawn.name,
       detectionRadius: spawn.detectionRadius ?? DEFAULT_DETECTION_RADIUS,
       aggroState: 'patrol' as const,
+      canPursue: spawn.canPursue ?? true, // Default: FOEs pursue when detected
+      enemyId: spawn.enemyId,
     })),
     encounterGauge: resetEncounterGauge(),
     facing: 'north',

--- a/src/systems/dungeon.ts
+++ b/src/systems/dungeon.ts
@@ -640,9 +640,12 @@ export function calculateFoePower(enemyId: string): number {
 /**
  * Determine FOE color based on party power vs FOE power ratio.
  *
- * - RED: FOE is 1.5x+ stronger (dangerous!)
- * - YELLOW: FOE is 0.8-1.5x player strength (fair fight)
- * - GREEN: FOE is <0.8x player strength (player advantage)
+ * - RED: FOE is 50%+ of party power (dangerous!)
+ * - YELLOW: FOE is 30-50% of party power (fair fight)
+ * - GREEN: FOE is <30% of party power (player advantage)
+ *
+ * Thresholds are tuned for early-game balance - a 120 HP FOE should feel
+ * dangerous to a level 1 party, not trivial.
  *
  * @returns Color tier for UI display
  */
@@ -659,7 +662,7 @@ export function getFoeColor(
 
   const ratio = foePower / playerPower
 
-  if (ratio >= 1.5) return 'red'
-  if (ratio >= 0.8) return 'yellow'
-  return 'green'
+  if (ratio >= 0.5) return 'red'    // FOE is 50%+ of party power
+  if (ratio >= 0.3) return 'yellow' // FOE is 30-50% of party power
+  return 'green'                     // FOE is <30% of party power
 }

--- a/src/systems/save.ts
+++ b/src/systems/save.ts
@@ -359,7 +359,7 @@ export function migrateLegacySaves(): GuildEntry | null {
       activePartyIds: party.activePartyIds ?? [],
     },
     inventory: {
-      gold: inventory?.gold ?? 100,
+      gold: inventory?.gold ?? 0,
       materials: inventory?.materials ?? {},
       soldMaterials: inventory?.soldMaterials ?? {},
       consumables: inventory?.consumables ?? {},

--- a/src/types/combat.ts
+++ b/src/types/combat.ts
@@ -387,6 +387,12 @@ export interface FleeFailedEvent extends CombatEvent {
   type: 'flee-failed';
 }
 
+export interface ReinforcementEvent extends CombatEvent {
+  type: 'reinforcement';
+  enemyName: string;
+  message: string;
+}
+
 /** Union of all combat events */
 export type CombatEventUnion =
   | DamageEvent
@@ -402,7 +408,8 @@ export type CombatEventUnion =
   | VictoryEvent
   | DefeatEvent
   | FleeSuccessEvent
-  | FleeFailedEvent;
+  | FleeFailedEvent
+  | ReinforcementEvent;
 
 // ============================================================================
 // Combat Initialization & Rewards

--- a/src/types/dungeon.ts
+++ b/src/types/dungeon.ts
@@ -24,6 +24,9 @@ export interface TileData {
 /** FOE movement behavior on the field */
 export type FoePatternType = 'patrol' | 'chase' | 'stationary'
 
+/** FOE aggro state */
+export type FoeAggroState = 'patrol' | 'aggro'
+
 /** Definition of a FOE spawn in the floor data */
 export interface FoeSpawnData {
   readonly id: string // e.g. "foe-floor1-a"
@@ -33,6 +36,8 @@ export interface FoeSpawnData {
   readonly patrolPath?: Position[]
   /** Display name shown on collision */
   readonly name: string
+  /** Detection radius for aggro (Manhattan distance). Default: 3 tiles. */
+  readonly detectionRadius?: number
 }
 
 /** Weighted enemy entry for encounter tables */
@@ -90,6 +95,10 @@ export interface FoeState {
   /** +1 or -1, direction of traversal along patrol path */
   readonly patrolDirection: 1 | -1
   readonly name: string
+  /** Detection radius for aggro (Manhattan distance). Default: 3 tiles. */
+  readonly detectionRadius: number
+  /** Current aggro state. Patrol FOEs switch to chase when aggro'd. */
+  readonly aggroState: FoeAggroState
 }
 
 /** Runtime state of the encounter gauge */
@@ -123,6 +132,7 @@ export interface DungeonState {
 /** Events that can occur during a turn */
 export type DungeonEvent =
   | { readonly type: 'foe-collision'; readonly foeId: string }
+  | { readonly type: 'foe-aggro'; readonly foeId: string }
   | { readonly type: 'random-encounter' }
   | { readonly type: 'reached-entrance' }
   | { readonly type: 'reached-exit' }

--- a/src/types/dungeon.ts
+++ b/src/types/dungeon.ts
@@ -141,6 +141,7 @@ export interface DungeonState {
 export type DungeonEvent =
   | { readonly type: 'foe-collision'; readonly foeId: string }
   | { readonly type: 'foe-aggro'; readonly foeId: string }
+  | { readonly type: 'foe-reinforcement'; readonly foeId: string; readonly foeName: string; readonly enemyId: string }
   | { readonly type: 'random-encounter' }
   | { readonly type: 'reached-entrance' }
   | { readonly type: 'reached-exit' }

--- a/src/types/dungeon.ts
+++ b/src/types/dungeon.ts
@@ -38,6 +38,10 @@ export interface FoeSpawnData {
   readonly name: string
   /** Detection radius for aggro (Manhattan distance). Default: 3 tiles. */
   readonly detectionRadius?: number
+  /** If true, FOE pursues player when detected. If false, stays on patrol (puzzle FOEs). Default: true. */
+  readonly canPursue?: boolean
+  /** Unique enemy ID for this FOE (e.g., "verdant-guardian"). Used for FOE encounters. */
+  readonly enemyId: string
 }
 
 /** Weighted enemy entry for encounter tables */
@@ -97,8 +101,12 @@ export interface FoeState {
   readonly name: string
   /** Detection radius for aggro (Manhattan distance). Default: 3 tiles. */
   readonly detectionRadius: number
-  /** Current aggro state. Patrol FOEs switch to chase when aggro'd. */
+  /** Current aggro state. Patrol FOEs switch to chase when aggro'd if canPursue is true. */
   readonly aggroState: FoeAggroState
+  /** If true, FOE pursues player when detected. If false, stays on patrol. */
+  readonly canPursue: boolean
+  /** Unique enemy ID for this FOE (e.g., "verdant-guardian"). */
+  readonly enemyId: string
 }
 
 /** Runtime state of the encounter gauge */


### PR DESCRIPTION
## Summary

Redesigns Floor 1 from a room-based layout to an organic corridor-based design inspired by Etrian Odyssey V's first FOE map. This addresses feedback that the original layout didn't support "wait and follow" FOE strategies.

## Changes

### Map Layout
- **Grid size**: 15x15 → 25x20 (larger for longer corridors)
- **Layout style**: Room-based → Winding organic corridors
- **Entry/Exit**: Entrance at (2,2), Exit at (21,18)
- **Key locations**: Checkpoint at (21,2), Shortcut at (12,18)

### FOE Behavior Overhaul
All FOEs now use **simple 3-tile patrol tracks** with **no pursuit** (canPursue: false)

| FOE | Position | Patrol Pattern | Purpose |
|-----|----------|----------------|---------|
| Thornblob | (7,7) | Vertical 3-tile | West corridor blocker |
| Elder Slime | (13,9) | Horizontal 3-tile | Central junction blocker |
| Guardblob | (22,9) | Vertical 3-tile | East corridor/checkpoint guard |
| Verdant Patrol | (10,16) | Horizontal 3-tile | South exit/shortcut guard |

### Design Goals
- Teach **timing and observation** over reflexes
- Enable **"wait and follow"** strategies (shadow FOEs through corridors)
- Provide **multiple routing options** (north, west, central, east paths)
- Create **strategic choke points** with predictable FOE patrols
- Feel more **exploratory** with winding corridors vs rectangular rooms

## Routing Options

Players can choose between:
1. **North Path**: Loop around (safer but longer)
2. **West Corridor**: Time past Thornblob's vertical patrol
3. **Central Junction**: Navigate Elder Slime's horizontal patrol
4. **East Corridor**: Final timing past Guardblob to checkpoint
5. **South Route**: Master timing to reach exit/shortcut

## Testing Needed

- [ ] Verify all 4 FOEs move on correct tracks
- [ ] Confirm no FOEs pursue player
- [ ] Test routing options (all paths should be viable)
- [ ] Check FOE colors (should be appropriate for level 1 party)
- [ ] Validate checkpoint/shortcut accessibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)